### PR TITLE
Feature client api restructure

### DIFF
--- a/app/js/bus/api/names/namesApi.js
+++ b/app/js/bus/api/names/namesApi.js
@@ -33,6 +33,10 @@ ozpIwc.NamesApi = ozpIwc.util.extend(ozpIwc.CommonApiBase, function(config) {
      * @default 3
      */
     this.heartbeatDropCount = config.heartbeatDropCount || 3;
+
+
+    this.apiMap = config.apiMap || ozpIwc.apiMap || {};
+
     // map the alias "/me" to "/address/{packet.src}" upon receiving the packet
     this.on("receive", function (packetContext) {
         var packet = packetContext.packet;
@@ -61,35 +65,18 @@ ozpIwc.NamesApi = ozpIwc.util.extend(ozpIwc.CommonApiBase, function(config) {
         pattern: /^\/api\/.*$/,
         contentType: "application/vnd.ozp-iwc-api-list-v1+json"
     }));
-    //temporary injector code. Remove when api loader is implemented
-    var packet = {
-        resource: '/api/data.api',
-        entity: {'actions': ['get', 'set', 'delete', 'watch', 'unwatch', 'addChild', 'removeChild', 'list']},
-        contentType: 'application/vnd.ozp-iwc-api-v1+json'
-    };
-    var node=this.findOrMakeValue(packet);
-    node.set(packet);
-    packet = {
-        resource: '/api/intents.api',
-        entity: {'actions': ['get','set','delete','watch','unwatch','register','invoke','broadcast', 'list']},
-        contentType: 'application/vnd.ozp-iwc-api-v1+json'
-    };
-    node=this.findOrMakeValue(packet);
-    node.set(packet);
-    packet = {
-        resource: '/api/names.api',
-        entity: {'actions': ['get','set','delete','watch','unwatch', 'list']},
-        contentType: 'application/vnd.ozp-iwc-api-v1+json'
-    };
-    node=this.findOrMakeValue(packet);
-    node.set(packet);
-    packet = {
-        resource: '/api/system.api',
-        entity: { 'actions': ['get','set','delete','watch','unwatch', 'list', 'launch']},
-        contentType: 'application/vnd.ozp-iwc-api-v1+json'
-    };
-    node=this.findOrMakeValue(packet);
-    node.set(packet);
+
+    for(var key in this.apiMap){
+        var api = this.apiMap[key];
+        var packet = {
+            resource: '/api/' + api.address,
+            entity: {'actions': api.actions},
+            contentType: 'application/vnd.ozp-iwc-api-v1+json'
+        };
+        var node=this.findOrMakeValue(packet);
+        node.set(packet);
+    }
+
     var self = this;
     this.dynamicNodes.forEach(function(resource) {
         self.updateDynamicNode(self.data[resource]);

--- a/app/js/client/apiMap.js
+++ b/app/js/client/apiMap.js
@@ -4,13 +4,13 @@ ozpIwc.apiMap = {
     "data.api" : { 'address': 'data.api',
         'actions': ["get","set","delete","watch","unwatch","list","addChild","removeChild"]
     },
-    "system.api" : { 'address': 'system.api',
-        'actions': ["get","set","delete","watch","unwatch","list","launch"]
+    "intents.api" : { 'address': 'intents.api',
+        'actions': ["get","set","delete","watch","unwatch","list","register","invoke","broadcast"]
     },
     "names.api" : { 'address': 'names.api',
         'actions': ["get","set","delete","watch","unwatch","list"]
     },
-    "intents.api" : { 'address': 'intents.api',
-        'actions': ["get","set","delete","watch","unwatch","list","register","invoke","broadcast"]
+    "system.api" : { 'address': 'system.api',
+        'actions': ["get","set","delete","watch","unwatch","list","launch"]
     }
 };

--- a/app/js/client/apiMap.js
+++ b/app/js/client/apiMap.js
@@ -1,0 +1,16 @@
+ozpIwc = ozpIwc || {};
+
+ozpIwc.apiMap = {
+    "data.api" : { 'address': 'data.api',
+        'actions': ["get","set","delete","watch","unwatch","list","addChild","removeChild"]
+    },
+    "system.api" : { 'address': 'system.api',
+        'actions': ["get","set","delete","watch","unwatch","list","launch"]
+    },
+    "names.api" : { 'address': 'names.api',
+        'actions': ["get","set","delete","watch","unwatch","list"]
+    },
+    "intents.api" : { 'address': 'intents.api',
+        'actions': ["get","set","delete","watch","unwatch","list","register","invoke","broadcast"]
+    }
+};

--- a/app/js/client/client.js
+++ b/app/js/client/client.js
@@ -158,7 +158,7 @@ ozpIwc.Client=function(config) {
     /**
      * @property watchMsgMap
      * @type Object
-     * @defualt {}
+     * @default {}
      */
     this.watchMsgMap = {};
     this.registeredCallbacks = {};
@@ -167,7 +167,7 @@ ozpIwc.Client=function(config) {
     /**
      * @property launchedIntents
      * @type Array
-     * @defualt []
+     * @default []
      */
     this.launchedIntents = [];
 
@@ -181,7 +181,8 @@ ozpIwc.Client=function(config) {
 
 /**
  * Parses launch parameters based on the raw string input it receives.
- * @property readLaunchParams
+ *
+ * @method readLaunchParams
  * @param {String} rawString
  */
 ozpIwc.Client.prototype.readLaunchParams=function(rawString) {
@@ -263,7 +264,7 @@ ozpIwc.Client.prototype.receive=function(packet) {
  * @method send
  * @param {String} dst Where to send the packet.
  * @param {Object} entity  The payload of the packet.
- * @param {Function} callback The Callback for any replies. The callback will be persisted if it $  returns a truth-like
+ * @param {Function} callback The Callback for any replies. The callback will be persisted if it returns a truth-like
  * value, canceled if it returns a false-like value.
  */
 ozpIwc.Client.prototype.send=function(fields,callback,preexistingPromiseRes,preexistingPromiseRej) {
@@ -339,6 +340,7 @@ ozpIwc.Client.prototype.send=function(fields,callback,preexistingPromiseRes,pree
 
 /**
  * Builds the client api calls from the values in client.apiMap
+ *
  * @method constructApiFunctions
  */
 ozpIwc.Client.prototype.constructApiFunctions = function(){
@@ -364,7 +366,12 @@ ozpIwc.Client.prototype.constructApiFunctions = function(){
     }
 };
 
-
+/**
+ * Calls the names.api to gather the /api/* resources to gain knowledge of available api actions of the current bus.
+ *
+ * @method gatherApiInformation
+ * @returns {Promise}
+ */
 ozpIwc.Client.prototype.gatherApiInformation = function(){
     var self = this;
     // gather api information
@@ -403,6 +410,7 @@ ozpIwc.Client.prototype.gatherApiInformation = function(){
 
 /**
  * Returns whether or not the Client is connected to the IWC bus.
+ *
  * @method isConnected
  * @returns {Boolean}
  */
@@ -428,6 +436,7 @@ ozpIwc.Client.prototype.cancelPromiseCallback=function(msgId) {
 
 /**
  * Cancel a watch callback registration.
+ *
  * @method cancelRegisteredCallback
  * @param (String} msgId The packet replyTo ID for which the callback was registered.
  *
@@ -445,6 +454,7 @@ ozpIwc.Client.prototype.cancelRegisteredCallback=function(msgId) {
 
 /**
  * Registers callbacks
+ *
  * @method on
  * @param {String} event The event to call the callback on.
  * @param {Function} callback The function to be called.
@@ -460,6 +470,7 @@ ozpIwc.Client.prototype.on=function(event,callback) {
 
 /**
  * De-registers callbacks
+ *
  * @method off
  * @param {String} event The event to call the callback on.
  * @param {Function} callback The function to be called.
@@ -471,6 +482,7 @@ ozpIwc.Client.prototype.off=function(event,callback) {
 
 /**
  * Disconnects the client from the IWC bus.
+ *
  * @method disconnect
  */
 ozpIwc.Client.prototype.disconnect=function() {
@@ -543,8 +555,7 @@ ozpIwc.Client.prototype.connect=function() {
             self.events.trigger("gotAddress", self);
 
             if(self.buildApisOnConnect) {
-                // gather api information
-                // Add any bus specific api functionality.
+                // gather api information then add any bus specific api functionality.
                 return self.gatherApiInformation().then(function(){
                     return self.constructApiFunctions();
                 });
@@ -590,6 +601,7 @@ ozpIwc.Client.prototype.connect=function() {
 
 /**
  * Creates an invisible iFrame Peer for IWC bus communication.
+ *
  * @method createIframePeer
  */
 ozpIwc.Client.prototype.createIframePeer=function() {
@@ -620,6 +632,16 @@ ozpIwc.Client.prototype.createIframePeer=function() {
     });
 };
 
+/**
+ * Handles intent invocation packets. Communicates back with the intents.api to operate the in flight intent state
+ * machine.
+ *
+ * @method intentInvocationHandling
+ * @param resource {String} The resource of the packet that sent the intent invocation
+ * @param intentResource {String} The in flight intent resource, used internally to operate the in flight intent state machine
+ * @param callback {Function} The intent handler's callback function
+ * @returns {Promise}
+ */
 ozpIwc.Client.prototype.intentInvocationHandling = function(resource,intentResource,callback) {
     var self = this;
     var res;
@@ -658,11 +680,27 @@ ozpIwc.Client.prototype.intentInvocationHandling = function(resource,intentResou
     });
 };
 
+/**
+ * Calls the specific api wrapper given an api name specified.
+ * If the wrapper does not exist it is created.
+ *
+ * @method api
+ * @param apiName {String} The name of the api.
+ * @returns {Function} returns the wrapper call for the given api.
+ */
 ozpIwc.Client.prototype.api=function(apiName) {
     return this.wrapperMap[apiName] || this.updateApi(apiName);
 };
 
 
+/**
+ * Updates the wrapper map for api use. Whenever functionality is added or removed from the apiMap the
+ * updateApi must be called to reflect said changes on the wrapper map.
+ *
+ * @method updateApi
+ * @param apiName {String} The name of the api
+ * @returns {Function} returns the wrapper call for the given api.
+ */
 ozpIwc.Client.prototype.updateApi = function(apiName){
     var augment = function (dst,action,client) {
         return function (resource, fragment, otherCallback) {

--- a/app/js/client/client.js
+++ b/app/js/client/client.js
@@ -136,11 +136,6 @@ ozpIwc.Client=function(config) {
     this.apiMap= ozpIwc.apiMap || {};
 
     /**
-     * A boolean flag to specify if apis should update with names.api-stored actions on connect.
-     * @type {Boolean}
-     */
-    this.buildApisOnConnect = config.buildApisOnConnect || false;
-    /**
      * @property wrapperMap
      * @type Object
      * @default {}
@@ -554,13 +549,6 @@ ozpIwc.Client.prototype.connect=function() {
              */
             self.events.trigger("gotAddress", self);
 
-            if(self.buildApisOnConnect) {
-                // gather api information then add any bus specific api functionality.
-                return self.gatherApiInformation().then(function(){
-                    return self.constructApiFunctions();
-                });
-            }
-        }).then(function() {
             // dump any queued sends, trigger that we are fully connected
             self.preconnectionQueue.forEach(function (p) {
                 self.send(p.fields, p.callback, p.promiseRes, p.promiseRej);

--- a/test/tests/client-integration/specs/clientSpec.js
+++ b/test/tests/client-integration/specs/clientSpec.js
@@ -139,12 +139,61 @@ describe("IWC Client", function() {
         });
     });
     describe("api Mappings", function(){
-        it(" gets its apiMap from names.api on connection",function(done){
+
+        it("has its apiMap at construction based on the ozpIwc.apiMap",function(){
             client=new ozpIwc.Client({
                 'peerUrl': "http://" + window.location.hostname + ":14002",
                 autoConnect: false
             });
-            expect(client.apiMap).toEqual({});
+            expect(client.apiMap['data.api']).not.toBeUndefined();
+            expect(client.apiMap['data.api'].functionName).toEqual('data');
+            expect(client.apiMap['data.api'].address).toEqual('data.api');
+            expect(client.apiMap['data.api'].actions.length).toBeGreaterThan(0);
+
+            expect(client.apiMap['names.api']).not.toBeUndefined();
+            expect(client.apiMap['names.api'].functionName).toEqual('names');
+            expect(client.apiMap['names.api'].address).toEqual('names.api');
+            expect(client.apiMap['names.api'].actions.length).toBeGreaterThan(0);
+
+            expect(client.apiMap['intents.api']).not.toBeUndefined();
+            expect(client.apiMap['intents.api'].functionName).toEqual('intents');
+            expect(client.apiMap['intents.api'].address).toEqual('intents.api');
+            expect(client.apiMap['intents.api'].actions.length).toBeGreaterThan(0);
+
+            expect(client.apiMap['system.api']).not.toBeUndefined();
+            expect(client.apiMap['system.api'].functionName).toEqual('system');
+            expect(client.apiMap['system.api'].address).toEqual('system.api');
+            expect(client.apiMap['system.api'].actions.length).toBeGreaterThan(0);
+        });
+
+        it("creates api function calls on creation",function(){
+            client=new ozpIwc.Client({
+                'peerUrl': "http://" + window.location.hostname + ":14002",
+                autoConnect: false
+            });
+            expect(client.data).not.toBeUndefined();
+            expect(client.names).not.toBeUndefined();
+            expect(client.system).not.toBeUndefined();
+            expect(client.intents).not.toBeUndefined();
+
+            expect(client.data()).toEqual(client.api('data.api'));
+            expect(client.names()).toEqual(client.api('names.api'));
+            expect(client.system()).toEqual(client.api('system.api'));
+            expect(client.intents()).toEqual(client.api('intents.api'));
+        });
+        it("can get its apiMap from names.api on connection",function(done){
+
+            ozpIwc.apiMap = {};
+            client=new ozpIwc.Client({
+                'peerUrl': "http://" + window.location.hostname + ":14002",
+                autoConnect: false,
+                buildApisOnConnect: true
+            });
+
+            expect(client.data).toBeUndefined();
+            expect(client.names).toBeUndefined();
+            expect(client.system).toBeUndefined();
+            expect(client.intents).toBeUndefined();
             client.connect().then(function() {
                 expect(client.apiMap['data.api']).not.toBeUndefined();
                 expect(client.apiMap['data.api'].functionName).toEqual('data');
@@ -168,21 +217,28 @@ describe("IWC Client", function() {
                 done();
             });
         });
-        it("creates api function calls on connection",function(done){
+        it("can overwrite api configurations with names.api data on connection",function(done){
+            ozpIwc.apiMap = {
+                "data.api": {
+                    'address': 'data.api',
+                    'actions': ["get"]
+                }
+            };
             client=new ozpIwc.Client({
                 'peerUrl': "http://" + window.location.hostname + ":14002",
-                autoConnect: false
+                autoConnect: false,
+                buildApisOnConnect: true
             });
-            expect(client.data).toBeUndefined();
-            expect(client.names).toBeUndefined();
-            expect(client.system).toBeUndefined();
-            expect(client.intents).toBeUndefined();
 
+            expect(client.data).not.toBeUndefined();
+            expect(client.data().get).not.toBeUndefined();
+            expect(client.apiMap['data.api'].actions.length).toEqual(1);
+            expect(client.data().set).toBeUndefined();
             client.connect().then(function() {
-                expect(client.data()).toEqual(client.api('data.api'));
-                expect(client.names()).toEqual(client.api('names.api'));
-                expect(client.system()).toEqual(client.api('system.api'));
-                expect(client.intents()).toEqual(client.api('intents.api'));
+                expect(client.data).not.toBeUndefined();
+                expect(client.data().get).not.toBeUndefined();
+                expect(client.data().set).not.toBeUndefined();
+                expect(client.apiMap['data.api'].actions.length).toBeGreaterThan(1);
                 done();
             });
         });

--- a/test/tests/client-integration/specs/clientSpec.js
+++ b/test/tests/client-integration/specs/clientSpec.js
@@ -181,67 +181,6 @@ describe("IWC Client", function() {
             expect(client.system()).toEqual(client.api('system.api'));
             expect(client.intents()).toEqual(client.api('intents.api'));
         });
-        it("can get its apiMap from names.api on connection",function(done){
-
-            ozpIwc.apiMap = {};
-            client=new ozpIwc.Client({
-                'peerUrl': "http://" + window.location.hostname + ":14002",
-                autoConnect: false,
-                buildApisOnConnect: true
-            });
-
-            expect(client.data).toBeUndefined();
-            expect(client.names).toBeUndefined();
-            expect(client.system).toBeUndefined();
-            expect(client.intents).toBeUndefined();
-            client.connect().then(function() {
-                expect(client.apiMap['data.api']).not.toBeUndefined();
-                expect(client.apiMap['data.api'].functionName).toEqual('data');
-                expect(client.apiMap['data.api'].address).toEqual('data.api');
-                expect(client.apiMap['data.api'].actions.length).toBeGreaterThan(0);
-
-                expect(client.apiMap['names.api']).not.toBeUndefined();
-                expect(client.apiMap['names.api'].functionName).toEqual('names');
-                expect(client.apiMap['names.api'].address).toEqual('names.api');
-                expect(client.apiMap['names.api'].actions.length).toBeGreaterThan(0);
-
-                expect(client.apiMap['intents.api']).not.toBeUndefined();
-                expect(client.apiMap['intents.api'].functionName).toEqual('intents');
-                expect(client.apiMap['intents.api'].address).toEqual('intents.api');
-                expect(client.apiMap['intents.api'].actions.length).toBeGreaterThan(0);
-
-                expect(client.apiMap['system.api']).not.toBeUndefined();
-                expect(client.apiMap['system.api'].functionName).toEqual('system');
-                expect(client.apiMap['system.api'].address).toEqual('system.api');
-                expect(client.apiMap['system.api'].actions.length).toBeGreaterThan(0);
-                done();
-            });
-        });
-        it("can overwrite api configurations with names.api data on connection",function(done){
-            ozpIwc.apiMap = {
-                "data.api": {
-                    'address': 'data.api',
-                    'actions': ["get"]
-                }
-            };
-            client=new ozpIwc.Client({
-                'peerUrl': "http://" + window.location.hostname + ":14002",
-                autoConnect: false,
-                buildApisOnConnect: true
-            });
-
-            expect(client.data).toBeDefined();
-            expect(client.data().get).toBeDefined();
-            expect(client.apiMap['data.api'].actions.length).toEqual(1);
-            expect(client.data().set).toBeUndefined();
-            client.connect().then(function() {
-                expect(client.data).toBeDefined();
-                expect(client.data().get).toBeDefined();
-                expect(client.data().set).toBeDefined();
-                expect(client.apiMap['data.api'].actions.length).toBeGreaterThan(1);
-                done();
-            });
-        });
     });
 
     describe("launch parameters",function() {

--- a/test/tests/client-integration/specs/clientSpec.js
+++ b/test/tests/client-integration/specs/clientSpec.js
@@ -230,14 +230,14 @@ describe("IWC Client", function() {
                 buildApisOnConnect: true
             });
 
-            expect(client.data).not.toBeUndefined();
-            expect(client.data().get).not.toBeUndefined();
+            expect(client.data).toBeDefined();
+            expect(client.data().get).toBeDefined();
             expect(client.apiMap['data.api'].actions.length).toEqual(1);
             expect(client.data().set).toBeUndefined();
             client.connect().then(function() {
-                expect(client.data).not.toBeUndefined();
-                expect(client.data().get).not.toBeUndefined();
-                expect(client.data().set).not.toBeUndefined();
+                expect(client.data).toBeDefined();
+                expect(client.data().get).toBeDefined();
+                expect(client.data().set).toBeDefined();
                 expect(client.apiMap['data.api'].actions.length).toBeGreaterThan(1);
                 done();
             });


### PR DESCRIPTION
Changes the default behavior of the IWC client to use the `ozpIwc.apiMap` resource to build its api function calls.

on connect gathering of api function calls can still be done with the client config property `buildApisOnConnect`. This allows overwriting of defaults set in ozpIwc.apiMap, but is intended for either/or usage.

This removes the need to wrap api calls in `client.connect().then(function(){...});` 