### PR TITLE
feat(client): Client connection issues prior to APIs ready.

### DIFF
--- a/demo/bouncingBalls/index.html
+++ b/demo/bouncingBalls/index.html
@@ -6,12 +6,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
 		<link rel="stylesheet" type="text/css" href="bouncingBalls.css">
-		
+
 		<script type="text/javascript" src="../js/ozpIwc-client.js"></script>
 		<script type="text/javascript" src="js/jquery-2.1.0.min.js"></script>
 	  	<script type="text/javascript" src="js/renderedBall.js"></script>
 		<script type="text/javascript" src="js/bouncingBalls.js"></script>
-			
   </head>
   <body>
 		<div class="header">
@@ -33,7 +32,7 @@
      viewbox="0 0 1000 1000"
      xmlns="http://www.w3.org/2000/svg">
 		 <rect x="0" y="0" width="100%" height="100%" fill-opacity="0.250"/>
-		
+
 		</svg>
   </body>
 </html>

--- a/demo/bouncingBalls/js/bouncingBalls.js
+++ b/demo/bouncingBalls/js/bouncingBalls.js
@@ -75,7 +75,7 @@ client.connect().then(function(){
             iwcClient: client
         }));
     })['catch'](function(err){
-        ozpIwc.log.log("Failed to push our ball: " + JSON.stringify(err,null,2));
+        console.log("Failed to push our ball: " + JSON.stringify(err,null,2));
     });
 
 	//=================================================================

--- a/demo/bouncingBalls/test.html
+++ b/demo/bouncingBalls/test.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script type="text/javascript" src="../js/ozpIwc-client.js"></script>
+    <script>
+        var client = new ozpIwc.Client({
+            peerUrl: "http://localhost:13000"
+        });
+        client.connect().then(function(){
+            console.log("Connected.");
+        });
+    </script>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
Client receives its address prior to APIs being instantiated, this causes initial packets to be sent but never handled. This is caused by the visibility API use (delay to prevent bus flooding when refresh is held).Delay added to allow the client to yield until  bus init. This will be replaced with an event driven implementation.

Bouncing balls updated.