### PR TITLE
Inflight Intent Cleanup

### DIFF
--- a/app/intentsChooser.html
+++ b/app/intentsChooser.html
@@ -135,7 +135,7 @@
                 contentType: intentInvocation.contentType,
                 entity: {
                 'state': "delivering",
-                    'handlerChosen' : {
+                    'handler' : {
                         'resource':handler.resource,
                         'reason': "userSelected"
                     }

--- a/app/js/services/api/intents/inFlightFSM.js
+++ b/app/js/services/api/intents/inFlightFSM.js
@@ -1,0 +1,214 @@
+/**
+ * @submodule bus.service.Util
+ */
+
+/**
+ * A Finite State Machine for in-flight intent resources. This state machine is static and manipulates the apiNodes
+ * it receives given the packet context received.
+ * @class InFlightIntentFSM
+ * @static
+ * @type {Object}
+ */
+ozpIwc.InFlightIntentFSM = {};
+
+//===============================================
+// States.
+// Called with node as scope.
+//===============================================
+/**
+ * A collection of states in the FSM. Each state is a function that is called when a node transitions to it via
+ * ozpIwc.InFlightFSM.transition.
+ * Each state function is called with the node's scope.
+ *
+ * @property states
+ * @type {Object}
+ */
+ozpIwc.InFlightIntentFSM.states ={};
+
+/**
+ * The initial state.
+ * This state immediately determines the next state of the node based on the number of handler choices it contains.
+ *
+ * @method init
+ * @returns {Object}
+ */
+ozpIwc.InFlightIntentFSM.states.init = function(){
+    var choices = this.entity.handlerChoices || [];
+    var nextEntity = {};
+
+    if(choices.length === 1){
+        nextEntity.handler = {
+            resource: choices[0].resource,
+            reason: "onlyOne"
+        };
+        nextEntity.state = "delivering";
+        //nextEntity.handlerChosen = this.entity.handlerChoices[0];
+    } else if (choices.length > 1){
+        nextEntity.state = "choosing";
+    } else {
+        nextEntity.state = "error";
+        nextEntity.error= "noChoices";
+    }
+    return ozpIwc.InFlightIntentFSM.transition(this,{entity: nextEntity});
+};
+
+/**
+ * The error handling state.
+ * This state is called when unexpected state changes and missing data occurs in the state
+ * machine.
+ *
+ * @method error
+ * @param {Object} entity The entity of the request packet received by the Api.
+ * @returns {Object}
+ */
+ozpIwc.InFlightIntentFSM.states.error=function(entity){
+    this.entity = this.entity || {};
+    this.entity.reply = entity.error;
+    this.entity.state = "error";
+    this.version++;
+    return this;
+};
+
+/**
+ * The delivering state.
+ * The node is in a delivering state when it's registered handler is called to operate on the
+ * intent data. The register handler will respond with "running" to signify it has received the request.
+ *
+ * @method delivering
+ * @param {Object} entity The entity of the request packet received by the Api.
+ * @returns {Object}
+ */
+ozpIwc.InFlightIntentFSM.states.delivering=function(entity){
+    if(!entity.handler || !entity.handler.resource || !entity.handler.reason) {
+        throw new ozpIwc.BadStateError("Choosing state requires a resource and reason");
+    }
+    this.entity.handler = entity.handler;
+    this.entity.state = "delivering";
+    this.version++;
+    return this;
+};
+
+/**
+ * The running state.
+ * The node is in a running state when the registered handler has received the request data. The
+ * node will transition to the "complete" state upon receiving a response from the handler's operation.
+ * @TODO currently running/complete are sent at once and no data is returned. When these states are sent the intent is handled.
+ *
+ * @method running
+ * @param {Object} entity The entity of the request packet received by the Api.
+ * @returns {Object}
+ */
+ozpIwc.InFlightIntentFSM.states.running=function(entity){
+    if(!entity.handler || !entity.handler.address) {
+        throw new ozpIwc.BadContentError("Entity lacks a 'handler.address' field");
+    }
+    this.entity.handler.address=entity.handler.address;
+    this.entity.state = "running";
+    this.version++;
+    return this;
+};
+
+/**
+ * The choosing state.
+ * The node is in a choosing state when:
+ *  (1) the intent chooser is opened.
+ *  (2) the api is gathering the preference-stored designated handler.
+ *
+ * The node will transition to delivering once the handler has been chosen.
+ *
+ * @method choosing
+ * @returns {Object}
+ */
+ozpIwc.InFlightIntentFSM.states.choosing=function(){
+    this.entity.state = "choosing";
+    this.version++;
+    return this;
+};
+
+/**
+ * The Complete state.
+ * Once the intent has been handled or canceled the node will transition to the complete state. From here the API
+ * will mark the node for deletion as it is no longer needed.
+ *
+ * @method complete
+ * @param {Object} entity The entity of the request packet received by the Api.
+ * @returns {*}
+ */
+ozpIwc.InFlightIntentFSM.states.complete=function(entity){
+    this.entity.reply=entity.reply;
+    this.entity.state = "complete";
+    this.version++;
+    return this;
+};
+
+
+//===============================================
+//State Transitions
+//===============================================
+/**
+ * A collection of state transitions for the Finite State machine. The first level of properties represent current state
+ * and the second level represents states that can be transitioned to.
+ *
+ * @property stateTransitions
+ * @type {Object}
+ */
+ozpIwc.InFlightIntentFSM.stateTransitions ={
+        "init": {
+            "init": ozpIwc.InFlightIntentFSM.states.init,
+            "error": ozpIwc.InFlightIntentFSM.states.error,
+            "delivering" : ozpIwc.InFlightIntentFSM.states.delivering,
+            "choosing": ozpIwc.InFlightIntentFSM.states.choosing
+        },
+        "choosing": {
+            "error": ozpIwc.InFlightIntentFSM.states.error,
+            "delivering" : ozpIwc.InFlightIntentFSM.states.delivering,
+            "complete": ozpIwc.InFlightIntentFSM.states.complete
+        },
+        "delivering": {
+            "error": ozpIwc.InFlightIntentFSM.states.error,
+            "running": ozpIwc.InFlightIntentFSM.states.running,
+            "complete": ozpIwc.InFlightIntentFSM.states.complete
+        },
+        "running": {
+            "error": ozpIwc.InFlightIntentFSM.states.error,
+            "complete": ozpIwc.InFlightIntentFSM.states.complete
+        },
+        "complete": {},
+        "error": {}
+};
+
+/**
+ * The transition utility function. This determines if the requested state change from the packet is valid, then
+ * calls the state transition and returns the modified node for storage.
+ * @method transition
+ * @param {ozpIwc.ApiNode} node
+ * @param {ozpIwc.PacketContext} [packet] If not provided, FSM assumes initial state trantition.
+ * @returns {ozpIwc.ApiNode}
+ */
+ozpIwc.InFlightIntentFSM.transition = function(node,packet){
+    packet = packet || {entity:{state: "init"}};
+    if(!packet.entity || !packet.entity.state) {
+        throw new ozpIwc.BadContentError("Entity lacks a 'state' field");
+    }
+    if(node.deleted){
+        throw new ozpIwc.BadContentError("Already handled.");
+    }
+    var transist=ozpIwc.InFlightIntentFSM.stateTransitions[node.entity.state];
+    if(!transist) {
+        // we're in a bad state.  pretty much unrecoverable
+        ozpIwc.InFlightIntentFSM.states.error.call(node, {
+            entity: {
+                error: "Inflight intent is in an invalid state.  Cannot proceed.",
+            }
+        });
+        return;
+    }
+
+    transist=transist[packet.entity.state];
+    if(!transist) {
+        throw new ozpIwc.BadStateError("In-flight intent cannot transition from "+
+            node.entity.state+" to "+packet.entity.state);
+    }
+
+    return transist.call(node,packet.entity);
+};

--- a/app/js/services/api/intents/intentsApi.js
+++ b/app/js/services/api/intents/intentsApi.js
@@ -30,6 +30,39 @@ ozpIwc.IntentsApi = ozpIwc.createApi(function(config) {
     ];
 });
 
+ozpIwc.IntentsApi.prototype.initializeData=function(deathScream) {
+    deathScream=deathScream || { watchers: {}, collectors: [], data: []};
+    this.watchers=deathScream.watchers;
+    this.collectors = deathScream.collectors;
+    deathScream.data.forEach(function(packet) {
+        if(packet.resource.indexOf("/inFlightIntent") === 0){
+            packet.entity = packet.entity || {};
+            packet.entity.dState = packet.entity.state;
+            packet.entity.state = "deserialize";
+            this.createNode({
+                resource: packet.resource, invokePacket: {},
+                handlerChoices:[0,1],
+                state: "deserialize"
+            },ozpIwc.IntentsInFlightNode).deserializeLive(packet);
+        }else {
+            this.createNode({resource: packet.resource}).deserializeLive(packet);
+        }
+    },this);
+
+    this.updateCollections();
+    if(this.endpoints) {
+        var self=this;
+        return Promise.all(this.endpoints.map(function(u) {
+            var e=ozpIwc.endpoint(u.link) ;
+            return self.loadFromEndpoint(e,u.headers).catch(function(e) {
+                ozpIwc.log.error(self.logPrefix,"load from endpoint ",e," failed: ",e);
+            });
+        }));
+    } else {
+        return Promise.resolve();
+    }
+};
+
 // turn on bulkGet and list for everything
 ozpIwc.IntentsApi.useDefaultRoute(["bulkGet", "list"]);
 
@@ -51,6 +84,7 @@ ozpIwc.IntentsApi.useDefaultRoute([ "watch", "unwatch", "delete"], "/inFlightInt
  * @returns {Promise}
  */
 ozpIwc.IntentsApi.prototype.invokeIntentHandler=function(packet,type,action,handlers,pattern) {
+    var self = this;
     var inflightNode = new ozpIwc.IntentsInFlightNode({
         resource: this.createKey("/inFlightIntent/"),
         src:packet.src,
@@ -63,11 +97,12 @@ ozpIwc.IntentsApi.prototype.invokeIntentHandler=function(packet,type,action,hand
     
     this.data[inflightNode.resource] = inflightNode;
     this.addCollector(inflightNode.resource);
-    this.addWatcher(inflightNode.resource,{src:packet.src,replyTo:packet.msgId});
+
+    this.data[inflightNode.resource] = ozpIwc.InFlightIntentFSM.transition(inflightNode);
     return this.handleInflightIntentState(inflightNode).then(function() {
         return {
             entity: {
-                inFlightIntent: inflightNode.resource
+                inFlightIntent: self.data[inflightNode.resource].toPacket()
             }
         };
     });
@@ -82,54 +117,14 @@ ozpIwc.IntentsApi.prototype.invokeIntentHandler=function(packet,type,action,hand
  * @returns {*}
  */
 ozpIwc.IntentsApi.prototype.handleInflightIntentState=function(inflightNode) {
-    var self=this;
-    var packet;
     switch(inflightNode.entity.state){
         case "choosing":
-            var showChooser=function(err) {
-                console.log("Picking chooser because",err);
-                ozpIwc.util.openWindow(ozpIwc.intentsChooserUri, {
-                    "ozpIwc.peer": ozpIwc.BUS_ROOT,
-                    "ozpIwc.intentSelection": "intents.api" + inflightNode.resource
-                },ozpIwc.INTENT_CHOOSER_FEATURES);
-            };
-            return this.getPreference(inflightNode.entity.intent.type+"/"+inflightNode.entity.intent.action).then(function(handlerResource) {
-                if(handlerResource in self.data) {
-                    inflightNode.setHandlerResource({
-                        'state': "delivering",
-                        'handlerChosen' : {
-                            'resource': handlerResource,
-                            'reason': "remembered"
-                        }
-                    });
-                } else {
-                    showChooser();
-                }
-            }).catch(showChooser);
+            return this.handleChoosing(inflightNode);
         case "delivering":
-            var handlerNode=this.data[inflightNode.entity.handlerChosen.resource];
-
-            packet = ozpIwc.util.clone(handlerNode.entity.invokeIntent);
-            packet.entity = packet.entity || {};
-            packet.replyTo = handlerNode.entity.replyTo;
-            packet.entity.inFlightIntent = inflightNode.resource;
-            packet.entity.inFlightIntentEntity= inflightNode.entity;
-            console.log(this.logPrefix+"delivering intent:",packet);
-            // TODO: packet permissions
-            this.send(packet);
+            this.handleDelivering(inflightNode);
             break;
         case "complete":
-            if(inflightNode.entity.invokePacket && inflightNode.entity.invokePacket.src && inflightNode.entity.reply) {
-                packet ={
-                    dst: inflightNode.entity.invokePacket.src,
-                    replyTo: inflightNode.entity.invokePacket.msgId,
-                    contentType: inflightNode.entity.reply.contentType,
-                    response: "complete",
-                    entity: inflightNode.entity.reply.entity
-                };
-                this.send(packet);
-            }
-            inflightNode.markAsDeleted();
+            this.handleComplete(inflightNode);
             break;
         default:
             break;
@@ -137,12 +132,87 @@ ozpIwc.IntentsApi.prototype.handleInflightIntentState=function(inflightNode) {
     return Promise.resolve();
 };
 
+/**
+ * A handler for the "choosing" state of an in-flight intent node.
+ * @method handleChoosing
+ * @param node
+ * @returns {Promise} Resolves when either a preference is gathered or the intent chooser is opened.
+ */
+ozpIwc.IntentsApi.prototype.handleChoosing = function(node){
+    var showChooser=function(err) {
+        console.log("Picking chooser because",err);
+        ozpIwc.util.openWindow(ozpIwc.intentsChooserUri, {
+            "ozpIwc.peer": ozpIwc.BUS_ROOT,
+            "ozpIwc.intentSelection": "intents.api" + node.resource
+        },ozpIwc.INTENT_CHOOSER_FEATURES);
+    };
+    var self = this;
+    return this.getPreference(node.entity.intent.type+"/"+node.entity.intent.action).then(function(handlerResource) {
+        if(handlerResource in self.data) {
+            node = ozpIwc.InFlightIntentFSM.transition(node,{
+                entity: {
+                    state: "delivering",
+                    'handler': {
+                        'resource': handlerResource,
+                        'reason': "remembered"
+                    }
+                }
+            });
+            self.handleInflightIntentState(node);
+        } else {
+            showChooser();
+        }
+    }).catch(showChooser);
+};
+
+/**
+ *  A handler for the "delivering" state of an in-flight intent node.
+ *  Sends a packet to the chosen handler.
+ *
+ *  @TODO should resolve on response from the handler that transitions the node to "running".
+ *
+ * @method handleDelivering
+ * @param {ozpIwc.ApiNode} node
+ */
+ozpIwc.IntentsApi.prototype.handleDelivering = function(node){
+    var handlerNode=this.data[node.entity.handler.resource];
+
+    var packet = ozpIwc.util.clone(handlerNode.entity.invokeIntent);
+    packet.entity = packet.entity || {};
+    packet.replyTo = handlerNode.entity.replyTo;
+    packet.entity.inFlightIntent = node.toPacket();
+    console.log(this.logPrefix+"delivering intent:",packet);
+    // TODO: packet permissions
+    return this.send(packet);
+};
+
+/**
+ * A handler for the "complete" state of an in-flight intent node.
+ * Sends notification to the invoker that the intent was handled & deletes the in-flight intent node as it is no longer
+ * needed.
+ *
+ * @method handleComplete
+ * @param {ozpIwc.ApiNode} node
+ */
+ozpIwc.IntentsApi.prototype.handleComplete = function(node){
+    if(node.entity.invokePacket && node.entity.invokePacket.src && node.entity.reply) {
+        this.send({
+            dst: node.entity.invokePacket.src,
+            replyTo: node.entity.invokePacket.msgId,
+            contentType: node.entity.reply.contentType,
+            response: "complete",
+            entity: node.entity.reply.entity
+        });
+    }
+    node.markAsDeleted();
+};
+
 ozpIwc.IntentsApi.declareRoute({
     action: "set",
     resource: "/inFlightIntent/{id}",
     filters: ozpIwc.standardApiFilters.setFilters(ozpIwc.IntentsInFlightNode)
 }, function(packet, context, pathParams) {
-    context.node.set(packet);
+    context.node = ozpIwc.InFlightIntentFSM.transition(context.node,packet);
     return this.handleInflightIntentState(context.node).then(function() {
         return {response: "ok"};
     });

--- a/app/js/services/node/intents/InflightIntentNode.js
+++ b/app/js/services/node/intents/InflightIntentNode.js
@@ -38,132 +38,13 @@ ozpIwc.IntentsInFlightNode = ozpIwc.util.extend(ozpIwc.ApiNode, function(config)
         'invokePacket': config.invokePacket,
         'contentType': config.invokePacket.contentType,
         'entity': config.invokePacket.entity,
-        'state': "choosing",
+        'state': "init",
         'status': "ok",
         'handlerChoices': config.handlerChoices,
-        'handlerChosen': {
-            'resource': null,
-            'reason': null
-        },
         'handler': {
             'resource': null,
             'address': null
         },
         'reply': null
     };
-    if(config.handlerChoices.length===1) {
-        this.entity.handlerChosen.resource=config.handlerChoices[0].resource;
-        this.entity.handlerChosen.reason="onlyOne";
-        this.entity.state="delivering";
-    }
 });
-
-/**
- * Sets the inFlight state to "error".
- *
- * @method setError
- * @param {Object} entity
- */
-ozpIwc.IntentsInFlightNode.prototype.setError=function(entity) {
-    this.entity.reply=entity.error;
-    this.entity.state = "error";
-    this.version++;
-};
-
-/**
- * Sets the handler chosen to the inFlight node.
- *
- * @method setHandlerResource
- * @param {Object} entity
- */
-ozpIwc.IntentsInFlightNode.prototype.setHandlerResource=function(entity) {
-    if(!entity.handlerChosen || !entity.handlerChosen.resource || !entity.handlerChosen.reason) {
-       throw new ozpIwc.BadStateError("Choosing state requires a resource and reason");
-    }
-    this.entity.handlerChosen = entity.handlerChosen;
-    this.entity.state = "delivering";
-    this.version++;
-};
-
-/**
- * Sets the handler participant that is running the inFlight node.
- *
- * @method setHandlerParticipant
- * @param {Object} entity
- */
-ozpIwc.IntentsInFlightNode.prototype.setHandlerParticipant=function(entity) {
-    if(!entity.handler || !entity.handler.address) {
-        throw new ozpIwc.BadContentError("Entity lacks a 'handler.address' field");
-    }
-    this.entity.handler=entity.handler;
-    this.entity.state = "running";
-    this.version++;
-};
-
-/**
- * Sets the inFlight state to "complete".
- *
- * @method setComplete
- * @param {Object} entity
- */
-ozpIwc.IntentsInFlightNode.prototype.setComplete=function(entity) {
-    this.entity.reply=entity.reply;
-    this.entity.state = "complete";
-    this.version++;
-};
-
-/**
- * The different states each state can transition to. Any given object level denotes a current state and its properties
- * are possible next states.
- *
- * @static
- * @property stateTransitions
- * @type {Object}
- */
-ozpIwc.IntentsInFlightNode.stateTransitions={
-    "choosing": {
-        "error": ozpIwc.IntentsInFlightNode.prototype.setError,
-        "delivering" : ozpIwc.IntentsInFlightNode.prototype.setHandlerResource,
-        "complete": ozpIwc.IntentsInFlightNode.prototype.setComplete
-    },
-    "delivering": {
-        "error": ozpIwc.IntentsInFlightNode.prototype.setError,
-        "running": ozpIwc.IntentsInFlightNode.prototype.setHandlerParticipant,
-        "complete": ozpIwc.IntentsInFlightNode.prototype.setComplete
-    },
-    "running": {
-        "error": ozpIwc.IntentsInFlightNode.prototype.setError,
-        "complete": ozpIwc.IntentsInFlightNode.prototype.setComplete
-    },
-    "complete": {},
-    "error": {}
-};
-
-/**
- * Set action for an IntentsInflightNode.
- *
- * @method set
- * @param {ozpIwc.TransportPacket} packet
- */
-ozpIwc.IntentsInFlightNode.prototype.set = function(packet) {
-    if(!packet.entity || !packet.entity.state) {
-        throw new ozpIwc.BadContentError("Entity lacks a 'state' field");
-    }
-    if(this.deleted){
-        throw new ozpIwc.BadContentError("Already handled.");
-    }
-    var transition=ozpIwc.IntentsInFlightNode.stateTransitions[this.entity.state];
-    if(!transition) {
-        // we're in a bad state.  pretty much unrecoverable
-        this.setError("Inflight intent is in an invalid state.  Cannot proceed.");
-        return;
-    }
-
-    transition=transition[packet.entity.state];
-    if(!transition) {
-        throw new ozpIwc.BadStateError("In-flight intent cannot transition from "+
-                this.entity.state+" to"+packet.entity.state);
-    }
-    
-    transition.call(this,packet.entity);
-};

--- a/test/tests/client-integration/specs/apis/systemApiSpec.js
+++ b/test/tests/client-integration/specs/apis/systemApiSpec.js
@@ -117,10 +117,7 @@ describe("System API", function() {
             ]);
         }).then(function(replies) {
             var intentsPacket=replies[1];
-            expect(intentsPacket.entity.inFlightIntent).toBeDefined();
-            return client.api("intents.api").get(intentsPacket.entity.inFlightIntent);
-        }).then(function(reply) {
-            expect(reply.entity).toEqual(jasmine.objectContaining({
+            expect(intentsPacket.entity.inFlightIntent.entity).toEqual(jasmine.objectContaining({
                 "entity": { 
                     'url': 'http://localhost:15001/?color=green',
                     'applicationId': '/application/23456',

--- a/test/tests/unit/specs/services/intents/intentApiSpec.js
+++ b/test/tests/unit/specs/services/intents/intentApiSpec.js
@@ -75,7 +75,8 @@ describe("Intent API Class", function () {
                     'resource': resource,
                     'action': "invoke",
                     'contentType' : "text/plain",
-                    'entity': "Some Text"
+                    'entity': "Some Text",
+                    'respondOn': "all"
                 },
                 'leaderState': "leader"
             });
@@ -131,7 +132,7 @@ describe("Intent API Class", function () {
                     dst: invocationPacket.packet.src,
                     response: "ok"
                 });
-                var inflightNode=apiBase.data[invocationPacket.responses[0].entity.inFlightIntent];
+                var inflightNode=invocationPacket.responses[0].entity.inFlightIntent;
                 expect(inflightNode.entity.state).toEqual("delivering");
             });
         });
@@ -142,15 +143,14 @@ describe("Intent API Class", function () {
                     dst: invocationPacket.packet.src,
                     response: "ok"
                 });
-                var inflightNode=apiBase.data[invocationPacket.responses[0].entity.inFlightIntent];
+                var inflightNode=apiBase.data[invocationPacket.responses[0].entity.inFlightIntent.resource];
                 expect(apiBase.participant).toHaveSent({
                     dst: "system.api",
                     resource: "/intentHandler",
                     action: "view",
-                    entity: jasmine.objectContaining({
-                        inFlightIntent: inflightNode.resource,
-                        inFlightIntentEntity: inflightNode.entity
-                    })
+                    entity: {
+                        inFlightIntent: inflightNode.toPacket()
+                    }
                 });
             });
         });
@@ -162,7 +162,7 @@ describe("Intent API Class", function () {
                     dst: invocationPacket.packet.src,
                     response: "ok"
                 });
-                var inflightNode=apiBase.data[invocationPacket.responses[0].entity.inFlightIntent];
+                var inflightNode=invocationPacket.responses[0].entity.inFlightIntent;
                 expect(inflightNode.entity.state).toEqual("choosing");
                 expect(ozpIwc.util.openWindow)
                     .toHaveBeenCalledWith(ozpIwc.intentsChooserUri,jasmine.objectContaining({
@@ -179,7 +179,7 @@ describe("Intent API Class", function () {
                     dst: invocationPacket.packet.src,
                     response: "ok"
                 });
-                var inflightNode=apiBase.data[invocationPacket.responses[0].entity.inFlightIntent];
+                var inflightNode=invocationPacket.responses[0].entity.inFlightIntent;
                 expect(inflightNode.entity.state).toEqual("delivering");
                 expect(ozpIwc.util.openWindow)
                     .not.toHaveBeenCalled();
@@ -193,7 +193,7 @@ describe("Intent API Class", function () {
                     dst: invocationPacket.packet.src,
                     response: "ok"
                 });
-                var inflightNode=apiBase.data[invocationPacket.responses[0].entity.inFlightIntent];
+                var inflightNode=invocationPacket.responses[0].entity.inFlightIntent;
                 expect(inflightNode.entity.state).toEqual("choosing");
                 expect(ozpIwc.util.openWindow)
                     .toHaveBeenCalledWith(ozpIwc.intentsChooserUri,jasmine.objectContaining({
@@ -207,7 +207,7 @@ describe("Intent API Class", function () {
             var invocationPacket=makeInvocationPacket(handlerResource);
             var inflightNode=null;
             return apiBase.receivePacketContext(invocationPacket).then(function() {
-                inflightNode=apiBase.data[invocationPacket.responses[0].entity.inFlightIntent];
+                inflightNode=invocationPacket.responses[0].entity.inFlightIntent;
                 var runningPacket=new TestPacketContext({'packet': {
                     'resource': inflightNode.resource,
                     'action': "set",
@@ -222,7 +222,7 @@ describe("Intent API Class", function () {
                 }});
                 return apiBase.receivePacketContext(runningPacket);
             }).then(function() {
-                expect(inflightNode.entity.state).toEqual("running");
+                expect(apiBase.data[inflightNode.resource].entity.state).toEqual("running");
             });
         });
     });


### PR DESCRIPTION
feat(intents): Added deserialize state. Custom initialize data to handle inflight intents. #279
feat(intents): Updated FSM.
feat(intents): removed custom initializeData & deserialize on inFlightIntents.
feat(intents): Updated documentation on FSM.
feat(intents): refactored handlerChosen to handler in in-flight intent node. #208
feat(intents): fixed inflight node format to match schema.
feat(intents): fixed tests.
feat(intents): intent handler response sent to registered callback of invoker.