### PR TITLE
Intent Chooser Updates

### DIFF
--- a/app/js/client/client.js
+++ b/app/js/client/client.js
@@ -66,8 +66,6 @@ ozpIwc.Client.prototype.genPeerUrlCheck = function(configUrl){
  * @method disconnect
  */
 ozpIwc.Client.prototype.disconnect=function() {
-    this.events.trigger("disconnect");
-
     if(this.iframe) {
         this.iframe.src = "about:blank";
         var self = this;

--- a/app/js/common/apiPromiseMixin.js
+++ b/app/js/common/apiPromiseMixin.js
@@ -441,11 +441,20 @@ ozpIwc.ApiPromiseMixin.getCore = function() {
                     }
                 });
             })['catch'](function(e){
-                console.log("Error in handling intent: ", e, " -- Clearing in-flight intent node:", res.resource);
-                self.send({
+                ozpIwc.log.log("Error in handling intent: ", e, " -- Reporting error on in-flight intent node:", res.resource);
+                // Respond to the inflight resource
+                return self.send({
                     dst: "intents.api",
+                    contentType: res.contentType,
+                    action: "set",
                     resource: res.resource,
-                    action: "delete"
+                    entity: {
+                        reply: {
+                            'entity': e || {},
+                            'contentType': res.entity.intent.type
+                        },
+                        state: "error"
+                    }
                 });
             });
         },
@@ -749,7 +758,7 @@ ozpIwc.ApiPromiseMixin.getCore = function() {
                 }
                 self.events.trigger("connected");
             })['catch'](function(e){
-                console.log(self.launchParams.inFlightIntent, " not handled, reason: ", e);
+                ozpIwc.log.error(self.launchParams.inFlightIntent, " not handled, reason: ", e);
                 self.events.trigger("connected");
             });
         }

--- a/app/js/services/api/system/systemApi.js
+++ b/app/js/services/api/system/systemApi.js
@@ -182,7 +182,7 @@ ozpIwc.SystemApi.declareRoute({
 }, function(packet,context,pathParams) {
     ozpIwc.log.info(this.logPrefix+" handling launchdata ",packet.entity);
     if(packet.entity && packet.entity.inFlightIntent){
-        ozpIwc.util.openWindow(packet.entity.inFlightIntentEntity.entity.url,{
+        ozpIwc.util.openWindow(packet.entity.inFlightIntent.entity.entity.url,{
             "ozpIwc.peer":ozpIwc.BUS_ROOT,
             "ozpIwc.inFlightIntent":packet.entity.inFlightIntent
         });

--- a/backend/routes/listing.js
+++ b/backend/routes/listing.js
@@ -26,7 +26,7 @@ var addPathing = function(resource){
     if(resource.charAt(0) !== "/") {
         resource = "/" + resource;
     }
-    resource = utils.getServerPath() + ServerConfig.APPLICATION_ROUTE +  resource;
+    resource = ServerConfig.APPLICATION_ROUTE +  resource;
     return resource;
 };
 
@@ -51,14 +51,6 @@ var fsGetListing = function(listingFile,callback){
             obj.launchUrls[i] = addPathing(obj.launchUrls[i]);
         }
 
-        // To comply with webtop's gathering of listings, providing a pre-formatted listing property.
-        obj.listing = {
-            'title': obj.title,
-                'uuid': obj.id,
-                'imageSmallUrl': obj.icons.small,
-                'imageMediumUrl': obj.icons.large,
-                'launchUrl': obj.launchUrls.default
-        };
         callback(obj);
     });
 };
@@ -89,12 +81,22 @@ var dbStoreListing = function(listing){
 var routeFormatListing = function(req,listing){
     listing.icons = listing.icons || {};
     listing.launchUrls = listing.launchUrls || {};
+
+    //Apply host name & protocol to url paths.
     for(var i in listing.icons){
         listing.icons[i] = utils.getHostUrl(req) + listing.icons[i];
     }
     for(var i in listing.launchUrls){
         listing.launchUrls[i] = utils.getHostUrl(req) + listing.launchUrls[i];
     }
+    // To comply with webtop's gathering of listings, providing a pre-formatted listing property.
+    listing.listing = {
+        'title': listing.title,
+        'uuid': listing.id,
+        'imageSmallUrl': listing.icons.small,
+        'imageMediumUrl': listing.icons.large,
+        'launchUrl': listing.launchUrls.default
+    };
 
     return listing;
 };

--- a/test/tests/unit/specs/services/system/systemApiSpec.js
+++ b/test/tests/unit/specs/services/system/systemApiSpec.js
@@ -174,12 +174,14 @@ describe("System API", function() {
                 action: 'invoke',
                 'entity' : {
                     'foo': 1,
-                    'inFlightIntent': '/intents/invocation/123',
-                    'inFlightIntentEntity': {
+                    'inFlightIntent': {
+                        'resource': '/intents/invocation/123',
                         'entity': {
-                            'url': "http://localhost:15000/?color=blue",
-                            "applicationId": "/application/abcApp",
-                            "launchData": "Hello World"
+                            'entity': {
+                                'url': "http://localhost:15000/?color=blue",
+                                "applicationId": "/application/abcApp",
+                                "launchData": "Hello World"
+                            }
                         }
                     }
                       


### PR DESCRIPTION
The intent chooser is now treated like all other intents, developers can choose to register custom intent choosers by registering against the `/inFlightIntent/chooser/choose` resource path of the Intents Api.

Documentation will follow, but since this is an advanced feature catered to grow functionality with ozp-webtop, most documentation will point to said implementation.

feat(intentsApi): Updated intent choosing to use hardcoded intent /inFlightIntent/chooser/choose so developers can use their own chooser.

feat(backend): Fixed path generators.
feat(systemApi): fixed application launcher's malformed inflightIntent.
feat(intentsApi): updated FSM to trigger events. Added fallback if no registered intent choosers.