### PR TITLE
Shared Web Worker Bus & Timers

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -19,6 +19,8 @@
   "trailing": true,
   "smarttabs": true,
   "globals": {
+    "self": false,
+    "WorkerGlobalScope": false,
     "angular": false,
     "ozpIwc": true,
     "File" : false,
@@ -29,6 +31,8 @@
     "xdescribe": false,
     "beforeEach": false,
     "afterEach": false,
+    "beforeAll": false,
+    "afterAll": false,
     "inject": false,
     "it": false,
     "xit": false,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,6 +14,7 @@ module.exports = function(grunt) {
 
         src: {
             common: [
+                'app/js/common/initials.js',
                 'bower_components/es5-shim/es5-shim.js',
                 'bower_components/es5-shim/es5-sham.js',
                 'bower_components/es6-promise/promise.js',
@@ -98,6 +99,10 @@ module.exports = function(grunt) {
                 'bower_components/vis/dist/vis.css',
                 'app/css/debugger/**/*.css'
             ],
+            workerTimerJs: [
+                'app/js/worker/timerThrottleUnlock.js',
+                'app/js/worker/timerThrottleUnlockRunner.js'
+            ],
             all: [
                 '<%= src.metrics %>',
                 '<%= src.bus %>',
@@ -114,6 +119,7 @@ module.exports = function(grunt) {
             ngMetricsJs: 'dist/js/<%= pkg.name %>-metrics-angular.js',
             debuggerJs: 'dist/js/debugger.js',
             debuggerCss: 'dist/css/debugger.css',
+            workerTimerJs: 'dist/js/ozpIwc.timer.js',
 
             busJsMin: 'dist/js/<%= pkg.name %>-bus.min.js',
             clientJsMin: 'dist/js/<%= pkg.name %>-client.min.js',
@@ -170,6 +176,10 @@ module.exports = function(grunt) {
             debugger: {
                 src: '<%= src.debugger %>',
                 dest: '<%= output.debuggerJs %>'
+            },
+            workerTimer: {
+                src: '<%= src.workerTimerJs %>',
+                dest: '<%= output.workerTimerJs %>'
             },
             debuggerCss: {
                 src: '<%= src.debuggerCss %>',
@@ -267,7 +277,7 @@ module.exports = function(grunt) {
                         expand: true,
                         nonull:true
                     },{
-                        src: ['ozpIwc.conf.js'],
+                        src: ['ozpIwc.conf.js', 'ozpIwc.loader.js'],
                         dest: './dist/js',
                         cwd: 'app/js',
                         expand: true,
@@ -374,7 +384,9 @@ module.exports = function(grunt) {
             all: [
                 'Gruntfile.js',
                 '<%= src.all %>',
-                '!bower_components/**/*'
+                '!bower_components/**/*',
+                '!app/js/client/timerThrottleUnlock.js',
+                '!app/js/worker/timerThrottleUnlock.js'
             ],
             test: {
                 src: ['<%= src.test %>']

--- a/app/iframe_peer.html
+++ b/app/iframe_peer.html
@@ -2,7 +2,7 @@
 <head>
     <title>Iframe Peer</title>
     <script type="text/javascript" src="js/ozpIwc.conf.js"></script>
-    <script type="text/javascript" src="js/ozpIwc-bus.js"></script>
+    <script type="text/javascript" src="js/ozpIwc.loader.js"></script>
 
   </head>
   <body>

--- a/app/js/bus/transport/participant/internal.js
+++ b/app/js/bus/transport/participant/internal.js
@@ -131,9 +131,9 @@ ozpIwc.transport.participant.Internal = (function (transport, util) {
         }
         var self = this;
         var send = transport.participant.Base.prototype.send;
-        util.setImmediate(function () {
+        //util.setImmediate(function () {
             send.call(self, packet);
-        });
+        //});
 
         return packet;
     };

--- a/app/js/bus/transport/participant/sharedWorker.js
+++ b/app/js/bus/transport/participant/sharedWorker.js
@@ -1,0 +1,191 @@
+var ozpIwc = ozpIwc || {};
+ozpIwc.transport = ozpIwc.transport || {};
+ozpIwc.transport.participant = ozpIwc.transport.participant || {};
+/**
+ * @module ozpIwc.transport
+ * @submodule ozpIwc.transport.participant
+ */
+
+
+
+ozpIwc.transport.participant.SharedWorker = (function (log, transport, util) {
+    /**
+     * @class SharedWorker
+     * @namespace ozpIwc.transport.participant
+     * @extends ozpIwc.transport.participant.Base
+     *
+     * @param {Object} config
+     * @param {String} config.origin
+     * @param {Object} config.sourceWindow
+     * @param {Object} config.credentials
+     * @param {Promise} [config.ready]
+     */
+    var SharedWorker = util.extend(transport.participant.Base, function (config) {
+        transport.participant.Base.apply(this, arguments);
+
+        /**
+         * The origin of the Participant.
+         * @property origin
+         */
+        /**
+         * The name of the Participant.
+         * @property name
+         */
+        this.origin = this.name = config.origin;
+
+        /**
+         * The MessageChannel port to communicate on
+         * @property sourceWindow
+         * @type Window
+         */
+        this.port = config.port;
+
+        /**
+         * @property credentials
+         * @type {Object}
+         */
+        this.credentials = config.credentials;
+
+        /**
+         * The type of the participant.
+         * @property participantType
+         * @type  String
+         * @default "postMessageProxy"
+         */
+        this.participantType = "postMessageProxy";
+
+        this.permissions.pushIfNotExist("ozp:iwc:origin", this.origin);
+
+        this.on("connectedToRouter", function () {
+            this.permissions.pushIfNotExist('ozp:iwc:address', this.address);
+            this.permissions.pushIfNotExist('ozp:iwc:sendAs', this.address);
+            this.permissions.pushIfNotExist('ozp:iwc:receiveAs', this.address);
+        }, this);
+        /**
+         * @property heartBeatStatus.origin
+         * @type String
+         */
+        this.heartBeatStatus.origin = this.origin;
+
+        var self = this;
+        this.port.addEventListener("message", function (e) {
+            var data = e.data;
+            if(typeof(data) === "string"){
+                try {
+                    data = JSON.parse(e.data);
+                } catch(e){
+                    // may not be failure, whomever gets forwarded the message
+                    // can choose to allow strings instead of objects.
+                }
+            }
+            if (data && data.windowEvent) {
+                self.handleWindowEvent(data.windowEvent);
+            }
+            self.forwardFromMessageChannel(data, e);
+        }, false);
+    });
+
+//--------------------------------------------------
+//          Private Methods
+//--------------------------------------------------
+    /**
+     * The participant hijacks anything addressed to "$transport" and serves it
+     * directly.  This isolates basic connection checking from the router, itself.
+     *
+     * @method handleTransportpacket
+     * @private
+     * @static
+     * @param {ozpIwc.transport.packet.SharedWorker} participant
+     * @param {Object} packet
+     */
+    var handleTransportPacket = function (participant, packet) {
+        var reply = {
+            'ver': 1,
+            'dst': participant.address,
+            'src': '$transport',
+            'replyTo': packet.msgId,
+            'msgId': participant.generateMsgId(),
+            'entity': {
+                "address": participant.address
+            }
+        };
+
+        participant.sendToRecipient(reply);
+    };
+
+
+//--------------------------------------------------
+//          Public Methods
+//--------------------------------------------------
+    /**
+     * Receives a packet on behalf of this participant and forwards it via SharedWorker.
+     *
+     * @method receiveFromRouterImpl
+     * @param {ozpIwc.transport.PacketContext} packetContext
+     */
+    SharedWorker.prototype.receiveFromRouterImpl = function (packetContext) {
+        this.sendToRecipient(packetContext.packet);
+    };
+
+    /**
+     * Sends a message to the other end of our connection.  Wraps any string mangling
+     * necessary by the SharedWorker implementation of the browser.
+     *
+     * @method sendToParticipant
+     * @param {ozpIwc.packet.Transport} packet
+     * @todo Only IE requires the packet to be stringified before sending, should use feature detection?
+     */
+    SharedWorker.prototype.sendToRecipient = function (packet) {
+        this.port.postMessage(packet);
+    };
+
+
+    /**
+     * Sends a packet received via SharedWorker to the Participant's router.
+     *
+     * @method forwardFromPostMessage
+     * @todo track the last used timestamp and make sure we don't send a duplicate messageId
+     * @param {ozpIwc.packet.Transport} packet
+     * @param {Event} event
+     */
+    SharedWorker.prototype.forwardFromMessageChannel = function (packet, event) {
+        if (typeof(packet) !== "object") {
+            log.error("Unknown packet received: " + JSON.stringify(packet));
+            return;
+        }
+        if (event.origin !== this.origin) {
+            /** @todo participant changing origins should set off more alarms, probably */
+            if (this.metrics) {
+                this.metrics.counter("transport." + this.address + ".invalidSenderOrigin").inc();
+            }
+            return;
+        }
+
+        packet = this.fixPacket(packet);
+
+        // if it's addressed to $transport, hijack it
+        if (packet.dst === "$transport") {
+            handleTransportPacket(this, packet);
+        } else {
+            this.router.send(packet, this);
+        }
+    };
+
+    /**
+     * A handler for forwarded events from this participants corresponding window.
+     * @TODO Currently just the event type is passed
+     * @method handleWindowEvent
+     * @param {String} eventType
+     */
+    SharedWorker.prototype.handleWindowEvent = function (eventType) {
+        switch (eventType) {
+            case "beforeunload":
+                this.leaveEventChannel();
+                break;
+        }
+
+    };
+
+    return SharedWorker;
+}(ozpIwc.log, ozpIwc.transport, ozpIwc.util));
+

--- a/app/js/bus/transport/participant/sharedWorkerListener.js
+++ b/app/js/bus/transport/participant/sharedWorkerListener.js
@@ -1,0 +1,189 @@
+var ozpIwc = ozpIwc || {};
+ozpIwc.transport = ozpIwc.transport || {};
+ozpIwc.transport.participant = ozpIwc.transport.participant || {};
+/**
+ * @module ozpIwc.transport
+ * @submodule ozpIwc.transport.participant
+ */
+
+
+ozpIwc.transport.participant.SharedWorkerListener = (function (log, transport, util) {
+    /**
+     * @TODO (DOC)
+     * Listens for Message Port PostMessage messages from outside the Shared Web Workerand forwards them to the
+     *     respected Participant.
+     *
+     * @class SharedWorkerListener
+     * @namespace ozpIwc.transport.participant
+     * @param {Object} [config]
+     * @param {ozpIwc.transport.Router} [config.router]
+     * @param {ozpIwc.metric.Registry} [config.metrics] The metric registry to put this modules metrics in. If no
+     *     registry metrics not taken
+     * @param {ozpIwc.policyAuth.PDP} [config.authorization] The authorization component for this module.
+     * @param {Promise} [config.ready]
+     */
+    var SharedWorkerListener = function (config) {
+        config = config || {};
+        if (!config.router) {
+            throw "PostMessage Listener requires a router.";
+        }
+        /**
+         * @property Participants
+         * @type ozpIwc.transport.participant.PostMessage[]
+         */
+        this.participants = [];
+
+        /**
+         * @property router
+         * @type ozpIwc.transport.Router
+         */
+        this.router = config.router;
+
+        /**
+         * Policy authorizing module.
+         * @property authorization
+         * @type {ozpIwc.policyAuth.PDP}
+         */
+        this.authorization = config.authorization;
+
+        /**
+         * Metric registry to store metrics on this link.
+         * @property metrics
+         * @type {ozpIwc.metric.Registry}
+         */
+        this.metrics = config.metrics;
+
+
+        var self = this;
+
+
+        util.addEventListener("connect", function (event) {
+            var port = event.ports[0];
+
+            var request = {
+                'subject': {'ozp:iwc:origin': event.origin},
+                'action': {'ozp:iwc:action': 'connect'},
+                'policies': self.authorization.policySets.connectSet
+            };
+
+            self.authorization.isPermitted(request)
+                .success(function () {
+                    var participant = new transport.participant.SharedWorker({
+                        'authorization': self.authorization,
+                        'origin': event.origin,
+                        'port': port
+                    });
+                    self.router.registerParticipant(participant);
+                    self.participants.push(participant);
+
+                    participant.port.start();
+
+                }).failure(function (err) {
+                    console.error("Failed to connect. Could not authorize:", err);
+                });
+        }, false);
+
+        if (this.metrics) {
+            this.metrics.gauge('transport.postMessageListener.participants').set(function () {
+                return self.getParticipantCount();
+            });
+        }
+    };
+
+    /**
+     * Gets the count of known participants
+     *
+     * @method getParticipantCount
+     *
+     * @return {Number} the number of known participants
+     */
+    SharedWorkerListener.prototype.getParticipantCount = function () {
+        if (!this.participants) {
+            return 0;
+        }
+        return this.participants.length;
+    };
+
+    /**
+     * Finds the participant associated with the given window.  Unfortunately, this is an
+     * o(n) algorithm, since there doesn't seem to be any way to hash, order, or any other way to
+     * compare windows other than equality.
+     *
+     * @method findParticipant
+     * @param {Object} sourceWindow - the participant window handle from message's event.source
+     */
+    SharedWorkerListener.prototype.findParticipant = function (sourceWindow) {
+        for (var i = 0; i < this.participants.length; ++i) {
+            if (this.participants[i].sourceWindow === sourceWindow) {
+                return this.participants[i];
+            }
+        }
+    };
+
+    /**
+     * Process a post message that is received from a peer
+     *
+     * @method receiveFromPostMessage
+     * @param {Object} event - The event received from the "message" event handler
+     * @param {String} event.origin
+     * @param {Object} event.source
+     * @param {ozpIwc.packet.Transport} event.data
+     */
+    SharedWorkerListener.prototype.receiveFromPostMessage = function (event) {
+        var participant = this.findParticipant(event.source);
+        var packet = event.data;
+        if (event.source === window) {
+            // the IE profiler seems to make the window receive it's own postMessages
+            // ... don't ask.  I don't know why
+            return;
+        }
+        if (typeof(event.data) === "string") {
+            try {
+                packet = JSON.parse(event.data);
+            } catch (e) {
+                // assume that it's some other library using the bus and let it go
+                return;
+            }
+        }
+
+        var isPacket = function (packet) {
+            if (util.isIWCPacket(packet)) {
+                participant.forwardFromPostMessage(packet, event);
+            } else {
+                log.debug("Packet does not meet IWC Packet criteria, dropping.", packet);
+            }
+        };
+
+        // if this is a window who hasn't talked to us before, sign them up
+        if (!participant) {
+
+            var self = this;
+            var request = {
+                'subject': {'ozp:iwc:origin': event.origin},
+                'action': {'ozp:iwc:action': 'connect'},
+                'policies': this.authorization.policySets.connectSet
+            };
+            this.authorization.isPermitted(request)
+                .success(function () {
+                    participant = new transport.participant.SharedWorker({
+                        'authorization': self.authorization,
+                        'origin': event.origin,
+                        'sourceWindow': event.source,
+                        'credentials': packet.entity,
+                        'ready': self.readyPromise
+                    });
+                    self.router.registerParticipant(participant, packet);
+                    self.participants.push(participant);
+                    isPacket(packet);
+
+                }).failure(function (err) {
+                    console.error("Failed to connect. Could not authorize:", err);
+                });
+        } else {
+            isPacket(packet);
+        }
+
+    };
+
+    return SharedWorkerListener;
+}(ozpIwc.log, ozpIwc.transport, ozpIwc.util));

--- a/app/js/bus/util/util.js
+++ b/app/js/bus/util/util.js
@@ -10,16 +10,6 @@ var ozpIwc = ozpIwc || {};
  * @static
  */
 ozpIwc.util = (function (util) {
-    /**
-     * Generates a large hexidecimal string to serve as a unique ID.  Not a guid.
-     *
-     * @method generateId
-     * @static
-     * @return {String}
-     */
-    util.generateId = function () {
-        return Math.floor(Math.random() * 0xffffffff).toString(16);
-    };
 
     /**
      * Invokes the callback handler on another event loop as soon as possible.

--- a/app/js/client/util/util.js
+++ b/app/js/client/util/util.js
@@ -1,0 +1,195 @@
+var ozpIwc = ozpIwc || {};
+ozpIwc.util = ozpIwc.util || {};
+/**
+ * @module ozpIwc
+ * @submodule ozpIwc.util
+ */
+
+ozpIwc.util = (function (util) {
+    //----------------------------------------------------------------
+    // Private properties
+    //----------------------------------------------------------------
+    var guid = util.generateId();
+    var timerId = 0;
+    var timerCallbacks = {};
+    var timerWorker;
+    var runLoc = "local";
+    var enhancedTimersEnabled = false;
+
+    var getTimerId = function () {
+        return guid + ":" + timerId++;
+    };
+
+    var useLocalTimers = function () {
+        return runLoc === "local";
+    };
+
+    var setLocalTimers = function () {
+        runLoc = "local";
+        for (var i in timerCallbacks) {
+            if (timerCallbacks[i].type === "setInterval" && timerCallbacks[i].loc === "sharedWorker") {
+                timerWorker.port.postMessage({
+                    type: "clearInterval",
+                    id: timerCallbacks[i].id
+                });
+                timerCallbacks[i].loc = "local";
+                timerCallbacks[i].locId = window.setInterval(timerCallbacks[i].callback, timerCallbacks[i].time, timerCallbacks[i].args);
+            }
+        }
+    };
+
+    var setSharedWorkerTimers = function () {
+        runLoc = "sharedWorker";
+        for (var i in timerCallbacks) {
+            if (timerCallbacks[i].type === "setInterval" && timerCallbacks[i].time < 1000 && timerCallbacks[i].loc === "local") {
+                window.clearInterval(timerCallbacks[i].locId);
+                timerCallbacks[i].loc = "sharedWorker";
+                timerWorker.port.postMessage({
+                    type: timerCallbacks[i].type,
+                    id: timerCallbacks[i].id,
+                    loc: timerCallbacks[i].loc,
+                    time: timerCallbacks[i].time
+                });
+            }
+        }
+    };
+
+    var clearCalls = function (type) {
+        return function (id) {
+            if (!enhancedTimersEnabled || !timerCallbacks[id]) {
+                return window.clearInterval(id);
+            } else if (timerCallbacks[id].loc === "local") {
+                window.clearInterval(timerCallbacks[id].locId);
+                timerCallbacks[id] = undefined;
+            } else {
+                timerWorker.port.postMessage({
+                    type: type,
+                    id: timerCallbacks[id].id
+                });
+                timerCallbacks[id] = undefined;
+            }
+        };
+    };
+
+    //----------------------------------------------------------------
+    // Public methods
+    //----------------------------------------------------------------
+
+    /**
+     * Creates connection the shared web worker and toggles util.setInterval and util.setTimeout to offload to the
+     * shared web worker when the window goes hidden.
+     * @method enableEnhancedTimers
+     */
+    util.enabledEnhancedTimers = function () {
+        if (window.SharedWorker) {
+            timerWorker = new SharedWorker('/js/ozpIwc.timer.js');
+
+            timerWorker.port.addEventListener('message', function (evt) {
+                console.log(evt);
+                var timer = evt.data;
+                var registered = timerCallbacks[timer.id];
+                if (registered) {
+                    registered.callback.call(window, registered.args);
+
+                    if (timer.type === "setTimeout") {
+                        timerCallbacks[timer.id] = null;
+                    }
+                }
+            });
+
+            document.addEventListener("visibilitychange", function runOnce(e) {
+                switch (document.visibilityState) {
+                    case "visible":
+                        setLocalTimers();
+                        break;
+                    case "hidden":
+                        setSharedWorkerTimers();
+                        break;
+                }
+            });
+
+            enhancedTimersEnabled = true;
+            timerWorker.port.start();
+        }
+    };
+
+    /**
+     * A wrapper around the window.setTimeout function, if the window is hidden this offloads to the shared worker
+     * if possible to avoid timer clamping.
+     *
+     * @method setTimeout
+     * @param {Function} cb The function to call after the time has passed
+     * @param {Number} time How long to wait to call the callback.
+     * @returns {Number|String} The id associated with the timeout.
+     */
+    util.setTimeout = function (cb, time) {
+        if (!enhancedTimersEnabled || useLocalTimers() || time && time >= 1000) {
+            return window.setTimeout(cb, time);
+        }
+        var timer = {
+            type: "setTimeout",
+            time: time,
+            id: getTimerId(),
+            callback: cb,
+            args: Array.prototype.slice.call(arguments, 2)
+        };
+
+        timerCallbacks[timer.id] = timer;
+        timerWorker.port.postMessage(timer);
+        return timer.id;
+    };
+
+    /**
+     * A wrapper around the window.setImmediate function, if the window is hidden this offloads to the shared worker
+     * if possible to avoid timer clamping.
+     *
+     * @method setTimeout
+     * @param {Function} cb The function to call after the time has passed
+     * @param {Number} time How often to call the callback.
+     * @returns {Number|String} The id associated with the timeout.
+     */
+    util.setInterval = function (cb, time) {
+        if (!enhancedTimersEnabled) {
+            return window.setInterval(cb, time);
+        }
+
+        var timer = {
+            type: "setInterval",
+            time: time,
+            id: getTimerId(),
+            callback: cb,
+            args: Array.prototype.slice.call(arguments, 2)
+        };
+
+        if (useLocalTimers() || time && time >= 1000) {
+            timer.loc = "local";
+            timer.locId = window.setInterval(cb, time);
+            timerCallbacks[timer.id] = timer;
+            return timer.locId;
+        }
+
+        timer.loc = "sharedWorker";
+        timerCallbacks[timer.id] = timer;
+
+        timerWorker.port.postMessage(timer);
+        return timer.id;
+    };
+
+    /**
+     * A wrapper around the window.clearInterval function. If the interval to clear is offloaded to the shared web
+     * worker notification must be sent to it to stop updating.
+     * @method clearInterval
+     * @param {Number|String} id
+     */
+    util.clearInterval = clearCalls("clearInterval");
+
+    /**
+     * A wrapper around the window.clearTimeout function.If the timeout to clear is offloaded to the shared web
+     * worker notification must be sent to it to stop it from firing.
+     * @method clearInterval
+     * @param {Number|String} id
+     */
+    util.clearTimeout = clearCalls("clearTimeout");
+
+    return util;
+}(ozpIwc.util));

--- a/app/js/common/initials.js
+++ b/app/js/common/initials.js
@@ -1,0 +1,2 @@
+/*jshint -W079 */
+var window = window || this;

--- a/app/js/common/util.js
+++ b/app/js/common/util.js
@@ -11,6 +11,17 @@ var ozpIwc = ozpIwc || {};
  */
 ozpIwc.util = (function (util) {
     /**
+     * Generates a large hexidecimal string to serve as a unique ID.  Not a guid.
+     *
+     * @method generateId
+     * @static
+     * @return {String}
+     */
+    util.generateId = function () {
+        return Math.floor(Math.random() * 0xffffffff).toString(16);
+    };
+
+    /**
      * Used to get the current epoch time.  Tests overrides this
      * to allow a fast-forward on time-based actions.
      *
@@ -426,8 +437,12 @@ ozpIwc.util = (function (util) {
      * @return {Promise}
      */
     util.prerender = function () {
+        if (util.runningInWorker()) {
+            return Promise.resolve();
+        }
+
         return new Promise(function (resolve, reject) {
-            if (document.visibilityState === undefined || (document.visibilityState !== "prerender" &&
+            if (document === undefined || document.visibilityState === undefined || (document.visibilityState !== "prerender" &&
                 document.visibilityState !== "unload")) {
                 resolve();
             } else {
@@ -439,6 +454,18 @@ ozpIwc.util = (function (util) {
                 });
             }
         });
+    };
+
+    var runningInWorkerCache = (typeof WorkerGlobalScope !== 'undefined' && this instanceof WorkerGlobalScope);
+    /**
+     * A utility to determine if this code is running in a HTML5 Worker. Used to decide on browser technologies
+     * to use.
+     * @method runningInWorker
+     * @static
+     * @return {Boolean}
+     */
+    util.runningInWorker = function () {
+        return runningInWorkerCache;
     };
 
     return util;

--- a/app/js/ozpIwc.loader.js
+++ b/app/js/ozpIwc.loader.js
@@ -1,0 +1,29 @@
+if(window.SharedWorker) {
+    var worker = new SharedWorker('/js/ozpIwc-bus.js');
+
+    // Receive messages from the client and forward to the IWC Bus (shared worker)
+    window.addEventListener('message',function(evt){
+       worker.port.postMessage(evt.data);
+    });
+
+    // When the client is closing, notify the shared worker so the IWC bus can clean up references
+    window.addEventListener('beforeunload',function(evt){
+       worker.port.postMessage({windowEvent: evt.type});
+    });
+
+    // Receive messages from the the IWC Bus (shared worker) and forward to the client
+    worker.port.addEventListener('message',function(evt){
+        window.parent.postMessage(evt.data, "*");
+    });
+    worker.port.start();
+} else {
+    //Fallback on loading individual bus instances
+    (function() {
+        var s = document.createElement('script');
+        s.type = 'text/javascript';
+        s.async = true;
+        s.src = 'js/ozpIwc-bus.js';
+        var x = document.getElementsByTagName('script')[0];
+        x.parentNode.insertBefore(s, x);
+    })();
+}

--- a/app/js/worker/timerThrottleUnlock.js
+++ b/app/js/worker/timerThrottleUnlock.js
@@ -1,0 +1,68 @@
+var ozpIwc = ozpIwc || {};
+ozpIwc.worker = ozpIwc.worker || {};
+/**
+ * Various scripts loaded into webWorkers to enhance the IWCs performance
+ * @module ozpIwc
+ * @submodule ozpIwc.worker
+ */
+
+/**
+ * A webWorker to mock timeouts for IWC Client users. When browser tabs are inactive, timers are raised to a minimum of
+ * 1 second. This will prevent that so that IWC Actions are not throttled. Loaded via a Blob, or through a
+ * worker-runnable script ozpIwc.timer.js.
+ *
+ * Not intended to be ran in the IWC code directly, this is opened in a separate web worker.
+ * Inspiration from MIT Licensed  https://github.com/turuslan/HackTimer.
+ *
+ * @namespace ozpIwc.worker
+ * @method timerThrottleUnlock
+ */
+ozpIwc.worker.timerThrottleUnlock = function() {
+    var timerRegistrations = {};
+
+
+    self.addEventListener('connect',function(evt){
+        var port = evt.ports[0];
+
+        port.addEventListener('message', function (evt) {
+            console.log(evt);
+            evt.data = evt.data || {};
+            var timer = evt.data;
+
+            // silently give up if not formatted right
+            if (!timer.hasOwnProperty("id")|| !timer.type) {
+                return;
+            }
+
+            timer.time = timer.time || 0;
+
+            //Take all requested timer types and instantiate them in the worker where inactive limits do not apply.
+            switch (timer.type) {
+                case "setTimeout":
+                    timerRegistrations[timer.id] = self.setTimeout(function () {
+                        port.postMessage(timer);
+                        timerRegistrations[timer.id] = null;
+                    }, timer.time);
+                    break;
+
+                case "clearTimeout":
+                    self.clearTimeout(timerRegistrations[timer.id]);
+                    timerRegistrations[timer.id] = null;
+                    break;
+
+                case "setInterval":
+                    timerRegistrations[timer.id] = self.setInterval(function () {
+                        port.postMessage(timer);
+                    }, timer.time);
+                    break;
+
+                case "clearInterval":
+                    self.clearInterval(timerRegistrations[timer.id]);
+                    timerRegistrations[timer.id] = null;
+                    break;
+            }
+        }, false);
+        port.start();
+
+    })
+};

--- a/app/js/worker/timerThrottleUnlockRunner.js
+++ b/app/js/worker/timerThrottleUnlockRunner.js
@@ -1,0 +1,4 @@
+ozpIwc = ozpIwc || {};
+ozpIwc.worker = ozpIwc.worker || {};
+
+(function(){ozpIwc.worker.timerThrottleUnlock();}());

--- a/demo/bouncingBalls/js/bouncingBalls.js
+++ b/demo/bouncingBalls/js/bouncingBalls.js
@@ -26,17 +26,20 @@ $(document).ready(function(){
     });
 
 
-	window.setInterval(function() {
+    ozpIwc.util.setInterval(function() {
 		var elapsed=(ozpIwc.util.now()-client.startTime)/1000;
 
 		$('#averageLatencies').text(
 			"Pkt/sec [sent: " + (client.sentPackets/elapsed).toFixed(1) + ", " +
 			"received: " + (client.receivedPackets/elapsed).toFixed(1) + "]"
 		);
-	},500);
+	},1000);
 });
 
-var client=new ozpIwc.Client({peerUrl:"http://" + window.location.hostname + ":13000"});
+var client=new ozpIwc.Client({
+    peerUrl:"http://" + window.location.hostname + ":13000",
+    enhancedTimers: true
+});
 client.connect().then(function(){
 	// setup
 	var viewPort=$('#viewport');
@@ -63,7 +66,7 @@ client.connect().then(function(){
 		lastUpdate=now;
 	};
 
-	window.setInterval(animate,1000/fps);
+	ozpIwc.util.setInterval(animate,1000/fps);
 
 
     //=================================================================

--- a/demo/bouncingBalls/js/renderedBall.js
+++ b/demo/bouncingBalls/js/renderedBall.js
@@ -62,7 +62,7 @@ var Ball=function(ballRef,svgElement,iwcClient) {
 			svgimg.setAttribute('y','-100');
 			self.el.appendChild(svgimg);
 			self.circle.setAttribute("class","svgHidden");
-			window.setTimeout(function(){
+			ozpIwc.util.setTimeout(function(){
 				self.remove();
 			},500);
 		}
@@ -177,7 +177,8 @@ var BallPublisher=function(config) {
 
 		self.iwc.data().set(this.resource,{
 			entity: ball,
-            respondOn: "error"
+            respondOn: "none",
+            'lifespan': "bound"
 		})['catch'](function(err){
             console.error(err);
         });

--- a/test/tests/client-integration/index.html
+++ b/test/tests/client-integration/index.html
@@ -1,34 +1,35 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <title>Integration Tests</title>
+<head>
+    <title>OZP IWC Client Integration Tests</title>
 
-        <link rel="shortcut icon" type="image/png" href="/jasmine-core/jasmine_favicon.png">
-        <link rel="stylesheet" type="text/css" href="/jasmine-core/jasmine.css">
-        <link rel="stylesheet" type="text/css" href="../../jasmine-iwc-html-reporter.css">
+    <link rel="shortcut icon" type="image/png" href="/jasmine-core/jasmine_favicon.png">
+    <link rel="stylesheet" type="text/css" href="/jasmine-core/jasmine.css">
+    <link rel="stylesheet" type="text/css" href="../../jasmine-iwc-html-reporter.css">
 
-        <script type="text/javascript" src="/jasmine-core/jasmine.js"></script>
-        <script type="text/javascript" src="../../jasmine-iwc-html-reporter.js"></script>
-        <script type="text/javascript" src="/jasmine-core/boot.js"></script>
-        <script type="text/javascript">
-            jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
-            // Clear out the window.name in case it's left over from previous failed tests
-            window.name = "";
-        </script>
+    <script type="text/javascript" src="/jasmine-core/jasmine.js"></script>
+    <script type="text/javascript" src="/lib/jasmine-promises.js"></script>
+    <script type="text/javascript" src="../../jasmine-iwc-html-reporter.js"></script>
+    <script type="text/javascript" src="/jasmine-core/boot.js"></script>
+    <script type="text/javascript" src="/lib/testTools.js"></script>
+    <script type="text/javascript">
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+        // Clear out the window.name in case it's left over from previous failed tests
+        window.name = "";
+    </script>
+    <script type="text/javascript" src="/js/ozpIwc-client.js"></script>
 
-        <script type="text/javascript" src="/js/ozpIwc-client.js"></script>
-        <script type="text/javascript" src="/lib/testTools.js"></script>
-        <script type="text/javascript" src="/lib/jasmine-promises.js"></script>
-        <script type="text/javascript" src="/mockParticipant/js/mockParticipant.js"></script>
+    <!-- Client -->
+    <script type="text/javascript" src="specs/clientSpec.js"></script>
+    <!-- Apis -->
+    <script type="text/javascript" src="specs/apis/dataApiSpec.js"></script>
+    <script type="text/javascript" src="specs/apis/intentsApiSpec.js"></script>
+    <script type="text/javascript" src="specs/apis/namesApiSpec.js"></script>
+    <script type="text/javascript" src="specs/apis/systemApiSpec.js"></script>
 
-        <script type="text/javascript" src="specs/clientSpec.js"></script>
-        <script type="text/javascript" src="specs/apis/namesApiSpec.js"></script>
-        <script type="text/javascript" src="specs/apis/dataApiSpec.js"></script>
-        <script type="text/javascript" src="specs/apis/intentsApiSpec.js"></script>
-        <script type="text/javascript" src="specs/apis/systemApiSpec.js"></script>
-    </head>
-    <body>
-        <script src="//localhost:35729/livereload.js"></script>
-        <div id="jasmineReport"></div>
-    </body>
+
+</head>
+<body>
+<script src="//localhost:35729/livereload.js"></script>
+</body>
 </html>

--- a/test/tests/client-integration/specs/apis/dataApiSpec.js
+++ b/test/tests/client-integration/specs/apis/dataApiSpec.js
@@ -1,160 +1,155 @@
-describe("Data API", function () {
-    var client, participant, resolve, reject, promise;
+describe("Data Api", function () {
+    var client, client2, dataApi, dataApi2;
+    var BUS_URL = "http://" + window.location.hostname + ":14002";
 
-    beforeEach(function(done) {
-        client=new ozpIwc.Client({
-            peerUrl: "http://" + window.location.hostname + ":14002"
-        });
-        participant=new ozpIwc.test.MockParticipant({
-            clientUrl: "http://" + window.location.hostname + ":14001",
-            'client': client
-        });
-
-        var gate=ozpIwc.testUtil.doneSemaphore(2,done);
-
-        participant.on("connected",gate);
-        client.on("connected",gate);
-
-        promise = new Promise(function(res,rej){
-            resolve=res;
-            reject=rej;
-        });
-    });
-
-    afterEach(function() {
-        client.disconnect();
-        participant.close();
-    });
-
-	pit("responds to a bulk get with matching entities", function() {
-		var packetOne={'resource': "/family", 'entity': "value1"};
-		var packetTwo={'resource': "/family_a", 'entity': "value2", 'contentType':"application/fake+b+json"};
-        var packetThree={'resource': "/family_b", 'entity': "value3"};
-        var packetFour={'resource': "/notfamily", 'entity': "value4"};
-
-		return client.api('data.api').set(packetOne.resource,{entity:packetOne.entity})
-			.then(function() {
-				return client.api('data.api').set(packetTwo.resource,{'entity':packetTwo.entity,'contentType':packetTwo.contentType});
-			}).then(function() {
-				return client.api('data.api').set(packetThree.resource,{'entity':packetThree.entity});
-			}).then(function() {
-				return client.api('data.api').set(packetFour.resource,{'entity':packetFour.entity});
-			}).then(function() {
-				return client.api('data.api').bulkGet("/family");
-			}).then(function(reply) {
-				expect(reply.response).toEqual("ok");
-				expect(reply.entity.length).toEqual(3);
-				expect(reply.entity[0]).toEqual(jasmine.objectContaining(packetOne));
-				expect(reply.entity[1]).toEqual(jasmine.objectContaining(packetTwo));
-				expect(reply.entity[2]).toEqual(jasmine.objectContaining(packetThree));
-			})['catch'](function(error) {
-				expect(error).toEqual('not have happened');
-			});
-	});
-
-    pit('sets a value visible to other clients',function() {
-        var packet={
-            'dst': "data.api",
-            'resource': "/test",
-            'action' : "set",
-            'entity' : { 'foo' : 1 }
-        };
-        participant.send(packet,function() {
-            resolve();
-        });
-        return promise.then(function(){
-            return client.api('data.api').get(packet.resource).then(function (reply) {
-                    expect(reply.entity).toEqual(packet.entity);
-            });
-        });
-    });
-
-    it('setting a value generates a change to other clients',function(done) {
-        var packet={
-            'dst': "data.api",
-            'resource': "/test",
-            'action' : "set",
-            'entity' : { 'foo' : 1 }
-        };
-        client.api('data.api').watch(packet.resource,function(reply,dn) {
-            expect(reply.entity.newValue).toEqual(packet.entity);
-            expect(reply.entity.oldValue).toBeUndefined();
-            expect(reply.entity.newCollection).toEqual([]);
-            expect(reply.entity.oldCollection).toEqual([]);
-            dn();
+    beforeAll(function (done) {
+        client = new ozpIwc.Client({peerUrl: BUS_URL});
+        client.connect().then(function () {
+            dataApi = client.data();
             done();
-        }).then(function(reply) {
-            expect(reply.response).toEqual("ok");
-            expect(reply.collection).toBeUndefined();
-            expect(reply.entity).toBeUndefined();
-            participant.send(packet);
         });
-
     });
-    pit('can get a value set by another participant',function(){
-        participant.send({
-            'dst': "data.api",
-                'resource': "/test",
-                'action' : "set",
-                'entity' : { 'foo' : 2 }
-        },function(response){
-            resolve();
-        });
-        return promise.then(function(){
-            return client.data().get('/test').then(function(reply){
-                expect(reply.entity).toEqual({"foo":2});
+
+    afterEach(function (done) {
+        dataApi.list('/').then(function (resp) {
+            var packets = [];
+            var resources = resp.entity || [];
+            resources.forEach(function (resource) {
+                packets.push(dataApi.messageBuilder.delete(resource));
+            });
+            dataApi.bulkSend(packets).then(function () {
+                Promise.all(packets).then(function () {
+                    done();
+                });
             });
         });
     });
-    pit("can delete a value set by someone else",function() {
-        participant.send({
-            'dst': "data.api",
-            'resource': "/test",
-            'action': "set",
-            'entity': {'foo': 2}
-        }, function (response) {
-            resolve();
+
+
+    describe("general", function () {
+
+        pit('Sets values to the data api', function () {
+            return dataApi.set('/test', {entity: "testData"}).then(function (packet) {
+                expect(packet.response).toEqual('ok');
+            });
         });
 
-        return promise.then(function() {
-            return client.data().get('/test');
-        }).then(function (reply) {
-            expect(reply.entity).toEqual({"foo": 2});
-            return client.data().delete('/test');
-        }). then(function (reply) {
-            expect(reply.response).toEqual("ok");
-            return client.data().get('/test');
-        })['catch'](function(error){
-            expect(error.response).toEqual("noResource");
+        pit ('Gets the contents of the data api', function() {
+            return dataApi.set('/test', {entity: "testData"}).then(function (packet) {
+                return dataApi.get('/test');
+            }).then(function (packet) {
+                expect(packet.response).toEqual('ok');
+            });
+        });
+
+        pit("responds to a bulk get with matching entities", function () {
+            var packetOne = {'resource': "/family", 'entity': "value1"};
+            var packetTwo = {'resource': "/family_a", 'entity': "value2", 'contentType': "application/fake+b+json"};
+            var packetThree = {'resource': "/family_b", 'entity': "value3"};
+            var packetFour = {'resource': "/notfamily", 'entity': "value4"};
+
+            return dataApi.set(packetOne.resource, {entity: packetOne.entity}).then(function () {
+                return dataApi.set(packetTwo.resource, {
+                    'entity': packetTwo.entity,
+                    'contentType': packetTwo.contentType
+                });
+            }).then(function () {
+                return dataApi.set(packetThree.resource, {'entity': packetThree.entity});
+            }).then(function () {
+                return dataApi.set(packetFour.resource, {'entity': packetFour.entity});
+            }).then(function () {
+                return dataApi.bulkGet("/family");
+            }).then(function (reply) {
+                expect(reply.response).toEqual("ok");
+                expect(reply.entity.length).toEqual(3);
+                expect(reply.entity[0]).toEqual(jasmine.objectContaining(packetOne));
+                expect(reply.entity[1]).toEqual(jasmine.objectContaining(packetTwo));
+                expect(reply.entity[2]).toEqual(jasmine.objectContaining(packetThree));
+            })['catch'](function (error) {
+                expect(error).toEqual('not have happened');
+            });
+        });
+
+        pit('[Meta] data api is cleaned up after every run',function() {
+            return client.data().get('/family').catch(function(error) {
+                expect(error.response).toEqual("noResource");
+            });
         });
     });
 
-    pit('Integration bus cleans up after every run',function() {
-        return client.data().get('/test')['catch'](function(error) {
-            expect(error.response).toEqual("noResource");
+    describe("client interaction", function () {
+        beforeAll(function (done) {
+            client2 = new ozpIwc.Client({peerUrl: BUS_URL, autoConnect: false});
+            client2.connect().then(function () {
+                dataApi2 = client2.data();
+                done();
+            });
+        });
+
+        afterAll(function () {
+            client2.disconnect();
+            client2 = undefined;
+        });
+
+        pit('sets a value visible to other clients', function () {
+            var entity = {'foo': 1};
+            return dataApi.set('/test', {entity: entity}).then(function (resp) {
+                return dataApi2.get('/test');
+            }).then(function (reply) {
+                expect(reply.entity).toEqual(entity);
+            });
+        });
+
+        it('setting a value generates a change to other clients', function (done) {
+            var entity = {'foo': 1};
+            dataApi.watch('/test2', function (reply, dn) {
+                expect(reply.entity.newValue).toEqual(entity);
+                expect(reply.entity.oldValue).toBeUndefined();
+                expect(reply.entity.newCollection).toEqual([]);
+                expect(reply.entity.oldCollection).toEqual([]);
+                dn();
+                done();
+            }).then(function (reply) {
+                expect(reply.response).toEqual("ok");
+                expect(reply.collection).toBeUndefined();
+                expect(reply.entity).toBeUndefined();
+                dataApi2.set('/test2', {'entity': entity});
+            });
+        });
+        pit("can delete a value set by someone else", function () {
+
+            return dataApi.set('/test', {'entity': {'foo': 1}}).then(function () {
+                return dataApi.get('/test');
+            }).then(function (reply) {
+                expect(reply.entity).toEqual({"foo": 1});
+                return dataApi2.delete('/test');
+            }).then(function (reply) {
+                expect(reply.response).toEqual("ok");
+                return dataApi.get('/test');
+            })['catch'](function (error) {
+                expect(error.response).toEqual("noResource");
+            });
         });
     });
 
     describe("Collections",function(){
         pBeforeEach(function(){
-            return client.data().set("/tester",{entity:123}).then(function(r){
-                console.log(r);
-
-            }).catch(function(e){
-                console.log(e);
+            return dataApi.set("/tester",{entity:123}).catch(function(e){
+                expect(e).toNotHappen();
             });
         });
+
         pit('Each resource has a collection property',function(){
-            return client.data().get('/tester').then(function(response){
+            return dataApi.get('/tester').then(function(response){
                 expect(response.collection).toEqual([]);
             });
         });
 
         pit('Each resource updates its collection property if it has a child added to it',function(){
             var response;
-            return client.data().addChild('/tester',{entity:456}).then(function(resp) {
+            return dataApi.addChild('/tester',{entity:456}).then(function(resp) {
                 response = resp;
-                return client.data().get('/tester');
+                return dataApi.get('/tester');
             }).then(function(reply){
                 expect(reply.collection.length).toEqual(1);
                 expect(reply.collection).toEqual([response.entity.resource]);
@@ -162,12 +157,12 @@ describe("Data API", function () {
         });
         pit('Each resource updates its collection property if it has children added to it',function(){
             var response1,response2;
-            return client.data().addChild('/tester',{entity:456}).then(function(resp) {
+            return dataApi.addChild('/tester',{entity:456}).then(function(resp) {
                 response1 = resp;
-                return client.data().addChild('/tester', {entity: 456});
+                return dataApi.addChild('/tester', {entity: 456});
             }).then(function(resp){
                 response2 = resp;
-                return client.data().get('/tester');
+                return dataApi.get('/tester');
             }).then(function(reply){
                 expect(reply.collection.length).toEqual(2);
                 expect(reply.collection).toEqual([response1.entity.resource,response2.entity.resource]);
@@ -176,23 +171,23 @@ describe("Data API", function () {
 
         pit('Each resource updates its collection property if it has children removed to it',function(){
             var response;
-            return client.data().addChild('/tester',{entity:456}).then(function(resp) {
+            return dataApi.addChild('/tester',{entity:456}).then(function(resp) {
                 response = resp;
-                return client.data().get('/tester');
+                return dataApi.get('/tester');
             }).then(function(reply){
                 expect(reply.collection.length).toEqual(1);
                 expect(reply.collection).toEqual([response.entity.resource]);
-                return client.data().removeChild('/tester',{entity:{resource: response.entity.resource}});
+                return dataApi.removeChild('/tester',{entity:{resource: response.entity.resource}});
             }).then(function(){
-                return client.data().get('/tester');
+                return dataApi.get('/tester');
             }).then(function(reply){
                 expect(reply.collection).toEqual([]);
             });
         });
 
         pit('A resource only updates if a child was added not a subresource being set.',function(){
-            return client.data().set('/tester/123', {entity:123}).then(function(){
-                return client.data().get('/tester');
+            return dataApi.set('/tester/123', {entity:123}).then(function(){
+                return dataApi.get('/tester');
             }).then(function(reply){
                 expect(reply.collection).toEqual([]);
             });
@@ -203,13 +198,13 @@ describe("Data API", function () {
                 resolve = res;
                 reject = rej;
             });
-            client.data().get('/tester').then(function(response){
+            dataApi.get('/tester').then(function(response){
                 expect(response.pattern).toBeUndefined();
-                return client.data().watch('/tester',function(reply){
+                return dataApi.watch('/tester',function(reply){
                     reject(reply);
                 });
             }).then(function(){
-                client.data().set('/tester/123',{entity:123});
+                dataApi.set('/tester/123',{entity:123});
             });
 
             window.setTimeout(function(){
@@ -223,9 +218,10 @@ describe("Data API", function () {
         it('A watched resource collects if it has a pattern',function(done){
             var resource = '/tester/123';
             client.data().set('/tester',{pattern: '/tester/'}).then(function(response){
-                return client.data().watch('/tester',function(reply){
+                return client.data().watch('/tester',function(reply,clearCB){
                     expect(reply.entity.newCollection).toEqual([resource]);
                     expect(reply.entity.oldCollection).toEqual([]);
+                    clearCB();
                     done();
                 });
             }).then(function(){
@@ -233,76 +229,5 @@ describe("Data API", function () {
             });
         });
     });
-    xit('can list children added by another client',function(done) {
 
-    });
-
-    xit('can remove children added by another client',function(done){
-
-    });
-
-    xit('gets a change notice on a child being added by another client',function(done){
-
-    });
-
-    xit('gets a change notice on a child being removed by another client',function(done){
-
-    });
-
-    xit('permissions on the entity restrict access to the origin',function(done){
-
-    });
-
-    describe('Data load test', function() {
-
-        pit ('Gets the contents of the data api', function() {
-            return client.data().get('/dashboard/12345').then(function (packet) {
-                    expect(packet.response).toEqual('ok');
-            });
-        });
-    });
-
-    describe('Legacy API Tests', function () {
-
-        afterEach(function (done) {
-            var called = false;
-            client.api('data.api').delete('/test')
-                .then(function (packet) {
-                    expect(packet.response).toEqual('ok');
-                })['catch'](function (error) {
-                    expect(error).toEqual('');
-                });
-            if (!called) {
-                called = true;
-                done();
-            }
-        });
-
-
-        pit('Client sets values', function () {
-            return client.api('data.api').set('/test', { entity: "testData"}).then(function (packet) {
-                    expect(packet.response).toEqual('ok');
-            });
-        });
-
-
-        pit('Client gets values', function () {
-            return client.api('data.api').set('/test', { entity: "testData"}).then(function (packet) {
-                return client.api('data.api').get('/test', {});
-            }).then(function (packet) {
-                    expect(packet.entity).toEqual('testData');
-            });
-        });
-
-        pit('Client deletes values', function () {
-            return client.api('data.api').delete('/test').then(function (packet) {
-                expect(packet.response).toEqual('ok');
-            });
-        });
-
-//        xdescribe('Collection-like Actions', function () {
-//
-//            //TODO implement if needed
-//        });
-    });
 });

--- a/test/tests/client-integration/specs/apis/namesApiSpec.js
+++ b/test/tests/client-integration/specs/apis/namesApiSpec.js
@@ -1,146 +1,45 @@
-/**
- * Network Integration
- */
+describe("Names Api", function () {
+    var client, namesApi;
+    var BUS_URL = "http://" + window.location.hostname + ":14002";
 
-
-describe("Names API", function () {
-    var client;
-    var participant;
-    
-    beforeEach(function(done) {
-        client=new ozpIwc.Client({
-            peerUrl: "http://" + window.location.hostname + ":14002"
+    beforeAll(function (done) {
+        client = new ozpIwc.Client({peerUrl: BUS_URL});
+        client.connect().then(function () {
+            namesApi = client.names();
+            done();
         });
-        participant=new ozpIwc.test.MockParticipant({
-            clientUrl: "http://" + window.location.hostname + ":14001",
-            'client': client
-        });
-        
-        var gate=ozpIwc.testUtil.doneSemaphore(2,done);
-//        window.setTimeout(done,10);
-
-        participant.on("connected",gate);
-        client.connect().then(gate,gate);
-    });
-    
-    afterEach(function() {
-        client.disconnect();
-        participant.close();
     });
 
-//
-//    describe("/address resources", function() {
-//        xit("returns info about myself via get /address/${client.address}",function(done) {
-//            
-//        });
-//
-//        xit("uses the /me alias for get /address/${client.address}",function(done) {
-//            
-//        });    
-//        xit("returns limited info about another client",function(done) {
-//            
-//        });
-//        xit("returns metrics information about me at /address/${client.address}/metrics",function(done) {
-//            
-//        });
-//
-//        xit("set action is noPerm",function(done) {
-//            
-//        });
-//        xit("delete action is noPerm",function(done) {
-//            
-//        });
-//
-//    });
-//    describe("/multicast resources",function() {
-//        xit("adds client to the group with an addChild action on /multicast/${name}",function(done) {
-//            
-//        });    
-//        xit("returns multicast group info for /multicast/${name}",function(done) {
-//            
-//        });
-//
-//        xit("returns the group members for /multicast/${name} for members",function(done) {
-//            
-//        });
-//        xit("returns metrics information about the multicast group at /multicast/${name}/metrics",function(done) {
-//            
-//        });
-//        
-//        xit("set action is noPerm",function(done) {
-//            
-//        });
-//        xit("delete action is noPerm",function(done) {
-//            
-//        });
-//
-//    });
-//    
-//    describe("/api resources",function() {
-//        xit("returns a list of APIs at /api",function(done) {
-//            
-//        });
-//        xit("returns a descriptor at /api/data.api",function(done) {
-//            
-//        });
-//        xit("returns API metrics at /api/data.api/metrics",function(done) {
-//            
-//        });
-//        
-//        xit("set action is noPerm",function(done) {
-//            
-//        });
-//        xit("delete action is noPerm",function(done) {
-//            
-//        });
-//    });
+    describe("general", function () {
 
-
-    describe("Legacy integration tests",function() {
-        var testId="/address/testAddress";
-
-        var testFragment = {
-            entity: {
-                name: 'testName',
-                address: 'testAddress',
-                participantType: 'testType'
-            },
-            contentType: 'application/vnd.ozp-iwc-address-v1+json'
-        };
-
-        pAfterEach(function() {
-            return client.api('names.api').delete(testId,testFragment);
-        });
-
-
-        pit('Client sets values', function() {
-            console.log("[Names Api Spec] Sending names.api set");
-            var rv=client.api('names.api').set(testId,testFragment)
-                .then(function(reply) {
-                    console.log("[Names Api Spec] Set succeeded with",reply);
-                    expect(reply.response).toEqual('ok');
-                });
-            rv.catch(function(e) {
-                console.log("[Names Api Spec] Set failed with ",e);
-            });
-            return rv;
-        });
-
-
-        pit('Client gets values', function () {
-            return client.api('names.api').set(testId,testFragment).then(function(reply) {
-                return client.api('names.api').get(testId, {});
-            }).then(function(reply) {
-                expect(reply.entity).toEqual(testFragment.entity);
+        pit('Gets api information', function() {
+            return namesApi.list('/api/').then(function(resp) {
+                expect(resp.entity.indexOf('/api/data.api')).toBeGreaterThan(-1);
+                expect(resp.entity.indexOf('/api/intents.api')).toBeGreaterThan(-1);
+                expect(resp.entity.indexOf('/api/names.api')).toBeGreaterThan(-1);
+                expect(resp.entity.indexOf('/api/system.api')).toBeGreaterThan(-1);
+                expect(resp.entity.indexOf('/api/locks.api')).toBeGreaterThan(-1);
             });
         });
 
-        pit('Client deletes values', function () {
-            return client.api('names.api').delete(testId,{'contentType': testFragment.contentType})
-                .then(function(reply) {
-                        expect(reply.response).toEqual('ok');
-                });
+        pit('Api information returns actions of the api', function(){
+            return namesApi.get('/api/names.api').then(function(resp){
+                expect(resp.entity.actions).toBeDefined();
+            });
         });
 
+        pit('Gets addresses of the names api', function () {
+            return namesApi.get('/address').then(function (packet) {
+                expect(packet.response).toEqual('ok');
+            });
+        });
+
+        xit('Denied set access to names api addresses', function() {
+
+        });
+
+        xit('Denied delete access to names api addresses', function() {
+
+        });
     });
 });

--- a/test/tests/client-integration/specs/apis/systemApiSpec.js
+++ b/test/tests/client-integration/specs/apis/systemApiSpec.js
@@ -1,130 +1,114 @@
-/**
- * Network Integration
- */
+describe("System Api", function () {
+    var client, systemApi;
+    var BUS_URL = "http://" + window.location.hostname + ":14002";
 
-
-describe("System API", function() {
-    var client;
-    var participant;
-    beforeEach(function(done) {
-        client = new ozpIwc.Client({
-            peerUrl: "http://" + window.location.hostname + ":14002",
-						params: {"log":"DEBUG"}
+    beforeAll(function (done) {
+        client = new ozpIwc.Client({peerUrl: BUS_URL});
+        client.connect().then(function () {
+            systemApi = client.system();
+            done();
         });
-        participant = new ozpIwc.test.MockParticipant({
-            clientUrl: "http://localhost:14001",
-            'client': client
-        });
-
-        var gate = ozpIwc.testUtil.doneSemaphore(3, done);
-        participant.on("connected", gate);
-        client.connect().then(gate, gate);
-				
-        // wait for the systemAPI to be available
-        client.api("system.api").list("/").then(gate,gate);
-
     });
 
-    afterEach(function() {
-        client.disconnect();
-        participant.close();
-    });
 
-    pit("has pretty name and email in /user", function() {
-        return client.api("system.api").get("/user")
-            .then(function(reply) {
+    describe("general", function () {
+
+        pit("has pretty name and email in /user", function () {
+            return systemApi.get("/user").then(function (reply) {
                 expect(reply.response).toEqual("ok");
                 expect(reply.entity).toBeDefined();
             });
-    });
-    pit("has system version in /system", function() {
-        return client.api("system.api").get("/system")
-            .then(function(reply) {
-                expect(reply.response).toEqual("ok");
-                expect(reply.entity).toBeDefined();
-            });
+        });
 
-    });
-		pit("lists the sampleData applications at /application", function() {
-        return client.api("system.api").get("/application")
-            .then(function(reply) {
-                expect(reply.response).toEqual("ok");
-                expect(reply.entity).toContain("/application/23456");
-                expect(reply.entity).toContain("/application/34567");
-                expect(reply.entity).toContain("/application/45678");
-                expect(reply.entity).toContain("/application/56789");
-                expect(reply.entity).toContain("/application/67890");
-            });
-
-    });
-
-    ["/application/1234", "/user", "/system"].forEach(function(resource) {
-        pit("denies set on " + resource, function() {
-            return client.api("system.api").set(resource, {entity: "blah"})
-                .then(function(reply) {
-                  return Promise.reject(reply);
-                }).catch(function(error) {
-                    expect(error.response).toEqual("badAction");
+        pit("has system version in /system", function () {
+            return systemApi.get("/system")
+                .then(function (reply) {
+                    expect(reply.response).toEqual("ok");
+                    expect(reply.entity).toBeDefined();
                 });
+
         });
 
-        pit("denies delete on " + resource, function() {
-            return client.api("system.api").delete(resource, {entity: "blah"})
-                .then(function(reply) {
-                    return Promise.rject(reply);
-                })['catch'](function(error) {
-                    expect(error.response).toEqual("badAction");
-                });
+        xit("lists the sampleData applications at /application", function () {
+            return systemApi.get("/application").then(function (reply) {
+                expect(reply.response).toEqual("ok");
+                //@TODO mock system api updates for testing
+                //expect(reply.entity).toContain("/application/23456");
+                //expect(reply.entity).toContain("/application/34567");
+                //expect(reply.entity).toContain("/application/45678");
+                //expect(reply.entity).toContain("/application/56789");
+                //expect(reply.entity).toContain("/application/67890");
+            });
         });
-    });
-    
-    pit("registers for the intent run /application/vnd.ozp-iwc-launch-data-v1+json/run/system.api",function() {
-        return client.api("intents.api").get("/application/vnd.ozp-iwc-launch-data-v1+json/run/system.api")
-				.then(function(reply) {
-						console.log("Received ",reply);
-						expect(reply.response).toEqual("ok");
-						expect(reply.entity.invokeIntent).toBeDefined();
-						expect(reply.entity.invokeIntent.action).toEqual("invoke");
-						expect(reply.entity.invokeIntent.dst).toEqual("system.api");
-        });
-    });
-    pit("launch on system.api invokes the intent run /application/vnd.ozp-iwc-launch-data-v1+json/run/system.api",function() {
-        // hijack the system.api's intent registration so that we get it
-       return client.api("intents.api").set("/application/vnd.ozp-iwc-launch-data-v1+json/run/system.api",{
-            contentType: "application/vnd.ozp-iwc-intent-handler-v1+json",
-            resource: "/application/vnd.ozp-iwc-launch-data-v1+json/run/system.api",
-            entity: {
-                label: "Launch in New Window",
-                invokeIntent: {
-                    dst: client.address,
-                    action: "invoke",
-                    resource: ""
-                }
-            }
-        }).then(function(reply) {
-            expect(reply.response).toEqual("ok");
-            return Promise.all([
-                client.api("system.api").launch("/application/23456",{
-                    entity: { "foo": 123 }
-                }),
-                new Promise(function(resolve,reject) {
-                    client.on("receive",function(packet) {
-                        if(packet.src==="intents.api" && packet.action==="invoke") {
-                            resolve(packet);
-                        }
+
+        ["/application/1234", "/user", "/system"].forEach(function (resource) {
+            pit("denies set on " + resource, function () {
+                return systemApi.set(resource, {entity: "blah"})
+                    .then(function (reply) {
+                        return Promise.reject(reply);
+                    }).catch(function (error) {
+                        expect(error.response).toEqual("badAction");
                     });
-                })
-            ]);
-        }).then(function(replies) {
-            var intentsPacket=replies[1];
-            expect(intentsPacket.entity.inFlightIntent.entity).toEqual(jasmine.objectContaining({
-                "entity": { 
-                    'url': 'http://localhost:15001/?color=green',
-                    'applicationId': '/application/23456',
-                    'launchData': Object({ foo: 123 }),
-                    'id': '25a3d034-31f1-4dbe-b9b4-03c8dad7b5f8' 
+            });
+            pit("denies delete on " + resource, function () {
+                return systemApi.delete(resource, {entity: "blah"})
+                    .then(function (reply) {
+                        return Promise.rject(reply);
+                    })['catch'](function (error) {
+                    expect(error.response).toEqual("badAction");
+                });
+            });
+        });
+
+        xit("registers for the intent run /application/vnd.ozp-iwc-launch-data-v1+json/run/system.api", function () {
+            return client.intents().get("/application/vnd.ozp-iwc-launch-data-v1+json/run/system.api")
+                .then(function (reply) {
+                    console.log("Received ", reply);
+                    expect(reply.response).toEqual("ok");
+                    expect(reply.entity.invokeIntent).toBeDefined();
+                    expect(reply.entity.invokeIntent.action).toEqual("invoke");
+                    expect(reply.entity.invokeIntent.dst).toEqual("system.api");
+                });
+        });
+
+        xit("launch on system.api invokes the intent run /application/vnd.ozp-iwc-launch-data-v1+json/run/system.api", function () {
+            // hijack the system.api's intent registration so that we get it
+            return client.intents().set("/application/vnd.ozp-iwc-launch-data-v1+json/run/system.api", {
+                contentType: "application/vnd.ozp-iwc-intent-handler-v1+json",
+                resource: "/application/vnd.ozp-iwc-launch-data-v1+json/run/system.api",
+                entity: {
+                    label: "Launch in New Window",
+                    invokeIntent: {
+                        dst: client.address,
+                        action: "invoke",
+                        resource: ""
+                    }
                 }
-            }));
+            }).then(function (reply) {
+                expect(reply.response).toEqual("ok");
+                return Promise.all([
+                    systemApi.launch("/application/23456", {
+                        entity: {"foo": 123}
+                    }),
+                    new Promise(function (resolve, reject) {
+                        client.on("receive", function (packet) {
+                            if (packet.src === "intents.api" && packet.action === "invoke") {
+                                resolve(packet);
+                            }
+                        });
+                    })
+                ]);
+            }).then(function (replies) {
+                var intentsPacket = replies[1];
+                expect(intentsPacket.entity.inFlightIntent.entity).toEqual(jasmine.objectContaining({
+                    "entity": {
+                        'url': 'http://localhost:15001/?color=green',
+                        'applicationId': '/application/23456',
+                        'launchData': Object({foo: 123}),
+                        'id': '25a3d034-31f1-4dbe-b9b4-03c8dad7b5f8'
+                    }
+                }));
+            });
         });
     });
 });

--- a/test/tests/unit/specs/services/apiBaseSpec.js
+++ b/test/tests/unit/specs/services/apiBaseSpec.js
@@ -54,24 +54,21 @@ describe("Base Api request handling",function() {
 // Basic Actions: Get
 //=====================================================================
     describe("action get",function() {
-        pit("returns a valid resource",function() {
+        it("returns a valid resource",function() {
             var context=testPacket({action:"get",resource:"/foo"});
-            console.log(apiBase);
-            return apiBase.receivePacketContext(context).then(function() {
-                expect(context.responses.length).toEqual(1);
-                expect(context.responses[0].response).toEqual("ok");
-                expect(context.responses[0].contentType).toEqual("text/plain");
-                expect(context.responses[0].entity).toEqual("hello world");
-            });
+            apiBase.receivePacketContext(context);
+            expect(context.responses.length).toEqual(1);
+            expect(context.responses[0].response).toEqual("ok");
+            expect(context.responses[0].contentType).toEqual("text/plain");
+            expect(context.responses[0].entity).toEqual("hello world");
         });
 
-        pit("returns noResource for non-existent resource",function() {
+        it("returns noResource for non-existent resource",function() {
             var context=testPacket({action:"get",resource:"/does-not-exist"});
-            return apiBase.receivePacketContext(context).then(function() {
-                expect(context.responses.length).toEqual(1);
-                expect(context.responses[0].response).toEqual("noResource");
-                expect(context.responses[0].entity).toBeDefined();
-            });
+            apiBase.receivePacketContext(context);
+            expect(context.responses.length).toEqual(1);
+            expect(context.responses[0].response).toEqual("noResource");
+            expect(context.responses[0].entity).toBeDefined();
         });
     });
     
@@ -81,27 +78,25 @@ describe("Base Api request handling",function() {
 //=====================================================================
 
     describe("action list",function() {
-        pit("returns an array of matching resources",function() {
+        it("returns an array of matching resources",function() {
             var context=testPacket({action:"list",resource:"/foo/"});
-            return apiBase.receivePacketContext(context).then(function() {
-                expect(context.responses.length).toEqual(1);
-                expect(context.responses[0].response).toEqual("ok");
-                expect(context.responses[0]).toEqual(jasmine.objectContaining({
-                    contentType: "application/json",
-                    entity: ["/foo/1","/foo/2"]
-                }));
-            });
+            apiBase.receivePacketContext(context);
+            expect(context.responses.length).toEqual(1);
+            expect(context.responses[0].response).toEqual("ok");
+            expect(context.responses[0]).toEqual(jasmine.objectContaining({
+                contentType: "application/json",
+                entity: ["/foo/1","/foo/2"]
+            }));
         });
-        pit("returns an empty list if nothing matches",function() {
+        it("returns an empty list if nothing matches",function() {
             var context=testPacket({action:"list",resource:"/does-not-exist/"});
-            return apiBase.receivePacketContext(context).then(function() {
-                expect(context.responses.length).toEqual(1);
-                expect(context.responses[0].response).toEqual("ok");
-                expect(context.responses[0]).toEqual(jasmine.objectContaining({
-                    contentType: "application/json",
-                    entity: []
-                }));
-            });
+            apiBase.receivePacketContext(context);
+            expect(context.responses.length).toEqual(1);
+            expect(context.responses[0].response).toEqual("ok");
+            expect(context.responses[0]).toEqual(jasmine.objectContaining({
+                contentType: "application/json",
+                entity: []
+            }));
         });
     });
 //=====================================================================
@@ -109,28 +104,26 @@ describe("Base Api request handling",function() {
 //=====================================================================
 
     describe("action bulkGet",function() {
-        pit("returns an array of matching resources",function() {
+        it("returns an array of matching resources",function() {
             var context=testPacket({action:"bulkGet",resource:"/foo/"});
-            return apiBase.receivePacketContext(context).then(function() {
-                expect(context.responses.length).toEqual(1);
-                expect(context.responses[0].response).toEqual("ok");
-                expect(context.responses[0].entity[0]).toEqual(jasmine.objectContaining({
-                    contentType: "text/plain",
-                    entity: "resource 1"
-                }));
-                expect(context.responses[0].entity[1]).toEqual(jasmine.objectContaining({
-                    contentType: "text/plain",
-                    entity: "resource 2"
-                }));
-            });
+            apiBase.receivePacketContext(context);
+            expect(context.responses.length).toEqual(1);
+            expect(context.responses[0].response).toEqual("ok");
+            expect(context.responses[0].entity[0]).toEqual(jasmine.objectContaining({
+                contentType: "text/plain",
+                entity: "resource 1"
+            }));
+            expect(context.responses[0].entity[1]).toEqual(jasmine.objectContaining({
+                contentType: "text/plain",
+                entity: "resource 2"
+            }));
         });
-        pit("returns an empty list if nothing matches",function() {
+        it("returns an empty list if nothing matches",function() {
             var context=testPacket({action:"bulkGet",resource:"/does-not-exist/"});
-            return apiBase.receivePacketContext(context).then(function() {
-                expect(context.responses.length).toEqual(1);
-                expect(context.responses[0].response).toEqual("ok");
-                expect(context.responses[0].entity).toEqual([]);
-            });
+            apiBase.receivePacketContext(context);
+            expect(context.responses.length).toEqual(1);
+            expect(context.responses[0].response).toEqual("ok");
+            expect(context.responses[0].entity).toEqual([]);
         });
 
     
@@ -140,46 +133,42 @@ describe("Base Api request handling",function() {
 // Basic Actions: set
 //=====================================================================
     describe("action set",function() {
-        pit("modifies an existant resource",function() {
+        it("modifies an existant resource",function() {
             var context=testPacket({
                     'resource': "/foo",
                     'action': "set",
                     'entity': { foo:1}
             });
-            return apiBase.receivePacketContext(context).then(function() {
-                expect(context.responses.length).toEqual(1);
-                expect(context.responses[0].response).toEqual("ok");
-                expect(apiBase.data["/foo"].entity).toEqual({foo:1});
-                
-            });
+            apiBase.receivePacketContext(context);
+            expect(context.responses.length).toEqual(1);
+            expect(context.responses[0].response).toEqual("ok");
+            expect(apiBase.data["/foo"].entity).toEqual({foo:1});
         });
 
-        pit("creates a non-existent resource",function() {
+        it("creates a non-existent resource",function() {
             var context=testPacket({
                     'resource': "/does-not-exist",
                     'action': "set",
                     'entity': { foo:1}
             });
-            return apiBase.receivePacketContext(context).then(function() {
-                expect(context.responses.length).toEqual(1);
-                expect(context.responses[0].response).toEqual("ok");
-                expect(apiBase.data["/does-not-exist"].entity).toEqual({foo:1});
-                
-            });
+            apiBase.receivePacketContext(context);
+            expect(context.responses.length).toEqual(1);
+            expect(context.responses[0].response).toEqual("ok");
+            expect(apiBase.data["/does-not-exist"].entity).toEqual({foo:1});
         });
-        pit("returns noMatch for a bad version pre-condition",function() {
+
+        it("returns noMatch for a bad version pre-condition",function() {
             var context=testPacket({
                     'resource': "/foo",
                     'action': "set",
                     'ifTag': 20,
                     'entity': { foo:1}
             });
-            return apiBase.receivePacketContext(context).then(function() {
-                expect(context.responses.length).toEqual(1);
-                expect(context.responses[0].response).toEqual("noMatch");
-                expect(context.responses[0].entity.expectedVersion).toEqual(20);
-                expect(context.responses[0].entity.actualVersion).toEqual(1);
-            });
+            apiBase.receivePacketContext(context);
+            expect(context.responses.length).toEqual(1);
+            expect(context.responses[0].response).toEqual("noMatch");
+            expect(context.responses[0].entity.expectedVersion).toEqual(20);
+            expect(context.responses[0].entity.actualVersion).toEqual(1);
         });
     });
 //=====================================================================
@@ -187,7 +176,7 @@ describe("Base Api request handling",function() {
 //=====================================================================
     describe("action bulkSend",function() {
 
-        pit("returns ok when receiving a formatted bulkSend",function(){
+        it("returns ok when receiving a formatted bulkSend",function(){
             var context = [];
             context.push(testPacket({
                 'resource': "/foo",
@@ -203,16 +192,14 @@ describe("Base Api request handling",function() {
                 'action': "bulkSend",
                 'entity': context
             });
-            return apiBase.receivePacketContext(bulkSendPacket).then(function() {
-                expect(bulkSendPacket.responses.length).toEqual(1);
-                expect(bulkSendPacket.responses[0].response).toEqual("ok");
-                expect(apiBase.data["/foo"].entity).toEqual({foo:1});
-                expect(apiBase.data["/foo1"].entity).toEqual({foo:2});
-
-            });
+            apiBase.receivePacketContext(bulkSendPacket);
+            expect(bulkSendPacket.responses.length).toEqual(1);
+            expect(bulkSendPacket.responses[0].response).toEqual("ok");
+            expect(apiBase.data["/foo"].entity).toEqual({foo:1});
+            expect(apiBase.data["/foo1"].entity).toEqual({foo:2});
         });
 
-        pit("returns ok when receiving a bulkSend with an error producing request",function(){
+        it("returns ok when receiving a bulkSend with an error producing request",function(){
             var context = [];
             context.push(testPacket({
                 'resource': "/foo",
@@ -228,50 +215,44 @@ describe("Base Api request handling",function() {
                 'action': "bulkSend",
                 'entity': context
             });
-            return apiBase.receivePacketContext(bulkSendPacket).then(function() {
-                expect(bulkSendPacket.responses.length).toEqual(1);
-                expect(bulkSendPacket.responses[0].response).toEqual("ok");
-                expect(apiBase.data["/foo"].entity).toEqual({foo:1});
-                expect(apiBase.data["/foo1"]).not.toBeDefined();
-
-            });
+            apiBase.receivePacketContext(bulkSendPacket);
+            expect(bulkSendPacket.responses.length).toEqual(1);
+            expect(bulkSendPacket.responses[0].response).toEqual("ok");
+            expect(apiBase.data["/foo"].entity).toEqual({foo:1});
+            expect(apiBase.data["/foo1"]).not.toBeDefined();
         });
     });
 //=====================================================================
 // Basic Actions: delete
 //=====================================================================
     describe("action delete",function() {
-        pit("deletes an existant resource",function() {
+        it("deletes an existant resource",function() {
             var context=testPacket({action:"delete",resource:"/foo"});
-            return apiBase.receivePacketContext(context).then(function() {
-                expect(context.responses.length).toEqual(1);
-                expect(context.responses[0].response).toEqual("ok");
-                expect(apiBase.data["/foo"].deleted).toEqual(true);
-                
-            });
+            apiBase.receivePacketContext(context);
+            expect(context.responses.length).toEqual(1);
+            expect(context.responses[0].response).toEqual("ok");
+            expect(apiBase.data["/foo"].deleted).toEqual(true);
         });
 
-        pit("deletes a non-existent resource",function() {
+        it("deletes a non-existent resource",function() {
             var context=testPacket({action:"delete",resource:"/does-not-exist"});
-            return apiBase.receivePacketContext(context).then(function() {
-                expect(context.responses.length).toEqual(1);
-                expect(context.responses[0].response).toEqual("ok");
-                expect(apiBase.data["/does-not-exist"]).toBeUndefined();
-                
-            });
+            apiBase.receivePacketContext(context);
+            expect(context.responses.length).toEqual(1);
+            expect(context.responses[0].response).toEqual("ok");
+            expect(apiBase.data["/does-not-exist"]).toBeUndefined();
         });
-        pit("returns noMatch for a bad version pre-condition",function() {
+
+        it("returns noMatch for a bad version pre-condition",function() {
             var context=testPacket({
                 action: "delete",
                 resource:"/foo",
                 ifTag: 20
             });
-            return apiBase.receivePacketContext(context).then(function() {
-                expect(context.responses.length).toEqual(1);
-                expect(context.responses[0].response).toEqual("noMatch");
-                expect(context.responses[0].entity.expectedVersion).toEqual(20);
-                expect(context.responses[0].entity.actualVersion).toEqual(1);
-            });
+            apiBase.receivePacketContext(context);
+            expect(context.responses.length).toEqual(1);
+            expect(context.responses[0].response).toEqual("noMatch");
+            expect(context.responses[0].entity.expectedVersion).toEqual(20);
+            expect(context.responses[0].entity.actualVersion).toEqual(1);
         });
     });
 //=====================================================================
@@ -291,57 +272,53 @@ describe("Base Api request handling",function() {
         afterEach(function() {
             watchContext=null;
         });
-        pit("returns the current value",function() {
-            return apiBase.receivePacketContext(watchContext).then(function() {
-                expect(watchContext.responses.length).toEqual(1);
-                expect(watchContext.responses[0].response).toEqual("ok");
-                expect(watchContext.responses[0].contentType).toEqual("text/plain");
-                expect(watchContext.responses[0].entity).toEqual("hello world");
-            });
+        it("returns the current value",function() {
+            apiBase.receivePacketContext(watchContext);
+            expect(watchContext.responses.length).toEqual(1);
+            expect(watchContext.responses[0].response).toEqual("ok");
+            expect(watchContext.responses[0].contentType).toEqual("text/plain");
+            expect(watchContext.responses[0].entity).toEqual("hello world");
         });
         
-        pit("notifies watchers when the resource value changes",function() {
+        it("notifies watchers when the resource value changes",function() {
             var context=testPacket({
                 resource: "/foo",
                 action: "set",
                 entity: { foo:1}
             });
-            return apiBase.receivePacketContext(watchContext).then(function() {
-                console.log("Sending set packet");
-                return apiBase.receivePacketContext(context);
-            }).then(pauseForPromiseResolution).then(function() {
-                console.log("Checking for change packet");
-                expect(apiBase.participant).toHaveSent({
-                    resource: "/foo",
-                    dst: "unitTest",
-                    replyTo: "i:100",
-                    entity: {
-                        newValue: { foo:1},
-                        oldValue: "hello world",
-                        newCollection: [],
-                        oldCollection: [],
-                        deleted: false
-                    }
-                });
+            apiBase.receivePacketContext(watchContext);
+            console.log("Sending set packet");
+            apiBase.receivePacketContext(context);
+            console.log("Checking for change packet");
+            expect(apiBase.participant).toHaveSent({
+                resource: "/foo",
+                dst: "unitTest",
+                replyTo: "i:100",
+                entity: {
+                    newValue: { foo:1},
+                    oldValue: "hello world",
+                    newCollection: [],
+                    oldCollection: [],
+                    deleted: false
+                }
             });
         });
-        pit("deleting the resource broadcasts to watchers",function() {
+
+        it("deleting the resource broadcasts to watchers",function() {
             var context=testPacket({action:"delete",resource:"/foo"});
-            return apiBase.receivePacketContext(watchContext).then(function() {
-                return apiBase.receivePacketContext(context);
-            }).then(pauseForPromiseResolution).then(function() {
-                expect(apiBase.participant).toHaveSent({
-                    resource: "/foo",
-                    dst: "unitTest",
-                    replyTo: "i:100",
-                    entity: {
-                        newValue: null,
-                        oldValue: "hello world",
-                        newCollection: null,
-                        oldCollection: [],
-                        deleted: true
-                    }
-                });
+            apiBase.receivePacketContext(watchContext);
+            apiBase.receivePacketContext(context);
+            expect(apiBase.participant).toHaveSent({
+                resource: "/foo",
+                dst: "unitTest",
+                replyTo: "i:100",
+                entity: {
+                    newValue: null,
+                    oldValue: "hello world",
+                    newCollection: null,
+                    oldCollection: [],
+                    deleted: true
+                }
             });
         });
     });
@@ -359,47 +336,44 @@ describe("Base Api request handling",function() {
             watchContext=null;
         });
         
-        pit("returns a null value",function() {
-            return apiBase.receivePacketContext(watchContext).then(function() {
-                expect(watchContext.responses.length).toEqual(1);
-                expect(watchContext.responses[0].response).toEqual("ok");
-                expect(watchContext.responses[0].contentType).toBeUndefined();
-                expect(watchContext.responses[0].entity).toBeUndefined();
-            });
+        it("returns a null value",function() {
+            apiBase.receivePacketContext(watchContext);
+            expect(watchContext.responses.length).toEqual(1);
+            expect(watchContext.responses[0].response).toEqual("ok");
+            expect(watchContext.responses[0].contentType).toBeUndefined();
+            expect(watchContext.responses[0].entity).toBeUndefined();
         });
-        pit("broadcasts to watchers when the resource is created",function() {
+
+        it("broadcasts to watchers when the resource is created",function() {
             var context=testPacket({
                 resource: "/does-not-exist",
                 action: "set",
                 entity: { foo:1}
             });
-            return apiBase.receivePacketContext(watchContext).then(function() {
-                return apiBase.receivePacketContext(context);
-            }).then(pauseForPromiseResolution).then(function() {
-                expect(apiBase.participant).toHaveSent({
-                    resource: "/does-not-exist",
-                    dst: "unitTest",
-                    replyTo: "i:100",
-                    entity: {
-                        newValue: { foo:1},
-                        oldValue: undefined,
-                        newCollection: [],
-                        oldCollection: [],
-                        deleted: false
-                    }
-                });
+            apiBase.receivePacketContext(watchContext);
+            apiBase.receivePacketContext(context);
+            expect(apiBase.participant).toHaveSent({
+                resource: "/does-not-exist",
+                dst: "unitTest",
+                replyTo: "i:100",
+                entity: {
+                    newValue: { foo:1},
+                    oldValue: undefined,
+                    newCollection: [],
+                    oldCollection: [],
+                    deleted: false
+                }
             });
         });
-        pit("a watch on a non-existant resource does not create that resource",function() {
+
+        it("a watch on a non-existant resource does not create that resource",function() {
             var context=testPacket({
                 resource: "/does-not-exist",
                 action: "get"
             });
-            return apiBase.receivePacketContext(watchContext).then(function() {
-                return apiBase.receivePacketContext(context);
-            }).then(pauseForPromiseResolution).then(function() {
-                expect(context.responses[0].response).toEqual("noResource");
-            });
+            apiBase.receivePacketContext(watchContext);
+            apiBase.receivePacketContext(context);
+            expect(context.responses[0].response).toEqual("noResource");
         });
 
     });
@@ -421,27 +395,25 @@ describe("Base Api request handling",function() {
             watchContext=null;
         });
         
-        pit("removes an existant watch",function() {
+        it("removes an existant watch",function() {
             var context=testPacket({
                 resource: "/foo",
                 action: "unwatch"
             });
-            return apiBase.receivePacketContext(watchContext).then(function() {
-                return apiBase.receivePacketContext(context);
-            }).then(function() {
-                expect(context.responses[0].response).toEqual("ok");
-                expect(apiBase.watchers["/foo"].length).toEqual(0);
-            });
+            apiBase.receivePacketContext(watchContext);
+            apiBase.receivePacketContext(context);
+            expect(context.responses[0].response).toEqual("ok");
+            expect(apiBase.watchers["/foo"].length).toEqual(0);
         });
-        pit("is a NOP if there is no watch",function() {
+
+        it("is a NOP if there is no watch",function() {
             var context=testPacket({
                 resource: "/foo",
                 action: "unwatch"
             });
-            return apiBase.receivePacketContext(context).then(function() {
-                expect(context.responses[0].response).toEqual("ok");
-                expect(apiBase.watchers["/foo"]).toBeUndefined(0);
-            });
+            apiBase.receivePacketContext(context);
+            expect(context.responses[0].response).toEqual("ok");
+            expect(apiBase.watchers["/foo"]).toBeUndefined(0);
         });
 
     });
@@ -488,15 +460,14 @@ describe("Base Api leadership handoff",function() {
                     action: "deathScream",
                     entity: deathScream
             }});
-            return apiBase.receivePacketContext(deathScreamPacket).then(function() {
-                // Check for ready state-- queueing packets as member, holding deathscream data
-                expect(apiBase.leaderState).toEqual("member");
-                expect(apiBase.isRequestQueueing).toEqual(true);
-                expect(apiBase.deathScream).toEqual(deathScream);
-                expect(apiBase.transitionToMemberReady).toHaveBeenCalledWith(deathScream);
-                // simulates the lock being gained
-                return apiBase.transitionToLoading();
-            }).then(function() {
+            apiBase.receivePacketContext(deathScreamPacket);
+            // Check for ready state-- queueing packets as member, holding deathscream data
+            expect(apiBase.leaderState).toEqual("member");
+            expect(apiBase.isRequestQueueing).toEqual(true);
+            expect(apiBase.deathScream).toEqual(deathScream);
+            expect(apiBase.transitionToMemberReady).toHaveBeenCalledWith(deathScream);
+            // simulates the lock being gained
+            return apiBase.transitionToLoading().then(function() {
                 expect(apiBase.leaderState).toEqual("leader");
                 expect(apiBase.initializeData).toHaveBeenCalledWith(deathScream);
             });
@@ -528,10 +499,9 @@ describe("Base Api leadership handoff",function() {
                     action: "deathScream",
                     entity: deathScream
             }});
-            return apiBase2.receivePacketContext(deathScreamPacket).then(function() {
+            apiBase2.receivePacketContext(deathScreamPacket);
                 // simulates the lock being gained
-                return apiBase2.transitionToLoading();
-            }).then(function() {
+            return apiBase2.transitionToLoading().then(function() {
                 expect(apiBase2.leaderState).toEqual("leader");
                 expect(apiBase2.data).toEqual(apiBase.data);
                 expect(apiBase2.watchers).toEqual(apiBase.watchers);

--- a/test/tests/unit/specs/services/names/namesApiSpec.js
+++ b/test/tests/unit/specs/services/names/namesApiSpec.js
@@ -1,220 +1,214 @@
-describe("Names API",function() {
+describe("Names API", function () {
 
-	var namesApi;
-    
-	beforeEach(function() {
+    var namesApi;
+
+    beforeEach(function () {
         var fakeRouter = new FakeRouter();
-		namesApi=new ozpIwc.api.names.Api({
+        namesApi = new ozpIwc.api.names.Api({
             authorization: ozpIwc.wiring.authorization,
             'name': "names.test.api",
-			'participant': new TestClientParticipant({
+            'participant': new TestClientParticipant({
                 authorization: ozpIwc.wiring.authorization,
                 router: fakeRouter
             }),
             'router': fakeRouter
-		});
-        namesApi.isRequestQueueing=false;
+        });
+        namesApi.isRequestQueueing = false;
         namesApi.leaderState = "leader";
-	});
+    });
 
-	afterEach(function() {
-		namesApi=null;
-	});
+    afterEach(function () {
+        namesApi = null;
+    });
 
-    pit("responds with badResource for arbitrary resources",function() {
-        var context=new TestPacketContext({
+    it("responds with badResource for arbitrary resources", function () {
+        var context = new TestPacketContext({
             'leaderState': "leader",
             'packet': {
                 'resource': "/doesNotExist",
                 'action': "get",
-                'msgId' : "1234",
-                'src' : "srcParticipant"
+                'msgId': "1234",
+                'src': "srcParticipant"
             }
         });
-        return namesApi.receivePacketContext(context).then(function() {
-            expect(context.responses[0].response).toEqual("badResource");
-        });
+        namesApi.receivePacketContext(context);
+        expect(context.responses[0].response).toEqual("badResource");
     });
-    
-    
-    [ {
+
+
+    [{
         'resource': "/address",
-        'contentType' : "application/json",
-        'entity' : []
-      },{
+        'contentType': "application/json",
+        'entity': []
+    }, {
         'resource': "/multicast",
-        'contentType' : "application/json",
-        'entity' : []
-      },{
+        'contentType': "application/json",
+        'entity': []
+    }, {
         'resource': "/router",
-        'contentType' : "application/json",
-        'entity' : []
-      },{
+        'contentType': "application/json",
+        'entity': []
+    }, {
         'resource': "/api",
-        'contentType' : "application/json",
-        'entity' :[
+        'contentType': "application/json",
+        'entity': [
             "/api/data.api",
             "/api/intents.api",
             "/api/names.api",
             "/api/system.api",
             "/api/locks.api"
         ]
-      }
-    ].forEach(function(r) {
-        describe("Resource tree root " + r.resource, function () {
-            var contextFor=function(action) {
-                return new TestPacketContext({
-                    'leaderState': "leader",
-                    'packet': {
-                        'resource': r.resource,
-                        'action': action,
-                        'msgId': "1234",
-                        'src': "srcParticipant"
-                    }
-                });
-            };
-            
-            pit("replies to get", function () {
-                var context=contextFor("get");
-                return namesApi.receivePacketContext(context).then(function() {
+    }
+    ].forEach(function (r) {
+            describe("Resource tree root " + r.resource, function () {
+                var contextFor = function (action) {
+                    return new TestPacketContext({
+                        'leaderState': "leader",
+                        'packet': {
+                            'resource': r.resource,
+                            'action': action,
+                            'msgId': "1234",
+                            'src': "srcParticipant"
+                        }
+                    });
+                };
+
+                it("replies to get", function () {
+                    var context = contextFor("get");
+                    namesApi.receivePacketContext(context);
                     expect(context.responses[0].response).toEqual("ok");
                     expect(context.responses[0].entity).toEqual(r.entity);
                     expect(context.responses[0].contentType).toEqual(r.contentType);
                 });
-            });
-            pit("replies to list", function () {
-                var context=contextFor("list");
-                return namesApi.receivePacketContext(context).then(function() {
+
+                it("replies to list", function () {
+                    var context = contextFor("list");
+                    namesApi.receivePacketContext(context);
                     expect(context.responses[0].response).toEqual("ok");
                     expect(context.responses[0].entity).toEqual(r.entity);
                     expect(context.responses[0].contentType).toEqual(r.contentType);
                 });
-            });
-            pit("replies to bulkGet", function () {
-                var context=contextFor("bulkGet");
-                return namesApi.receivePacketContext(context).then(function() {
+
+                it("replies to bulkGet", function () {
+                    var context = contextFor("bulkGet");
+                    namesApi.receivePacketContext(context);
                     expect(context.responses[0].response).toEqual("ok");
                     expect(
-                        context.responses[0].entity.map(function(e) { 
+                        context.responses[0].entity.map(function (e) {
                             return e.resource;
                         })
                     ).toEqual(r.entity);
                     expect(context.responses[0].contentType).toEqual(r.contentType);
                 });
-            });
-            pit("responds with noPermission when attempting to set",function() {
-                var context=new TestPacketContext({
-                    'leaderState': "leader",
-                    'packet': {
-                        'resource': r.resource,
-                        'action': "set",
-                        'msgId' : "1234",
-                        'src' : "srcParticipant",
-                        'entity' : { 'foo' : 1 }
-                    }
-                });
-                return namesApi.receivePacketContext(context).then(function() {
+
+                it("responds with noPermission when attempting to set", function () {
+                    var context = new TestPacketContext({
+                        'leaderState': "leader",
+                        'packet': {
+                            'resource': r.resource,
+                            'action': "set",
+                            'msgId': "1234",
+                            'src': "srcParticipant",
+                            'entity': {'foo': 1}
+                        }
+                    });
+                    namesApi.receivePacketContext(context);
                     expect(context.responses[0].response).toEqual("noPermission");
                 });
             });
         });
-    });
-    
-    [ {
+
+    [{
         'resource': "/address",
-        'contentType' : "application/vnd.ozp-iwc-address-v1+json",
-        'listContentType' : "application/json"
-    },{
+        'contentType': "application/vnd.ozp-iwc-address-v1+json",
+        'listContentType': "application/json"
+    }, {
         'resource': "/multicast",
-        'contentType' : "application/vnd.ozp-iwc-multicast-address-v1+json",
-        'listContentType' : "application/json"
-    },{
+        'contentType': "application/vnd.ozp-iwc-multicast-address-v1+json",
+        'listContentType': "application/json"
+    }, {
         'resource': "/api",
-        'contentType' : "application/vnd.ozp-iwc-api-v1+json",
-        'listContentType' : "application/json"
-    },{
+        'contentType': "application/vnd.ozp-iwc-api-v1+json",
+        'listContentType': "application/json"
+    }, {
         'resource': "/router",
-        'contentType' : "application/vnd.ozp-iwc-router-v1+json",
-        'listContentType' : "application/json"
+        'contentType': "application/vnd.ozp-iwc-router-v1+json",
+        'listContentType': "application/json"
     }
-    ].forEach(function(r) {
-    describe("Resource tree " + r.resource, function () {
+    ].forEach(function (r) {
+            describe("Resource tree " + r.resource, function () {
 
-        pit("allows  " + r.contentType + " when setting a value in the tree",function() {
-            var context=new TestPacketContext({
-                'leaderState': "leader",
-                'packet': {
-                    'resource': r.resource + "/testValue",
-                    'contentType': r.contentType,
-                    'action': "set",
-                    'msgId' : "1234",
-                    'src' : "srcParticipant",
-                    'entity' : { 'foo' : 1 }
-                }
-            });
-            return namesApi.receivePacketContext(context).then(function() {
-                expect(context.responses[0].response).toEqual("ok");
-            });
+                it("allows  " + r.contentType + " when setting a value in the tree", function () {
+                    var context = new TestPacketContext({
+                        'leaderState': "leader",
+                        'packet': {
+                            'resource': r.resource + "/testValue",
+                            'contentType': r.contentType,
+                            'action': "set",
+                            'msgId': "1234",
+                            'src': "srcParticipant",
+                            'entity': {'foo': 1}
+                        }
+                    });
+                    namesApi.receivePacketContext(context);
+                    expect(context.responses[0].response).toEqual("ok");
 
+                });
+
+                it("updates the collection when setting a value in the tree", function () {
+                    var resourceName = r.resource + "/testValue";
+                    namesApi.data[resourceName] = new ozpIwc.api.base.Node({
+                        'resource': resourceName,
+                        'contentType': r.contentType,
+                        'entity': {'foo': 1}
+                    });
+                    var context = new TestPacketContext({
+                        'leaderState': "leader",
+                        'packet': {
+                            'resource': r.resource,
+                            'action': "get",
+                            'msgId': "1234",
+                            'src': "srcParticipant"
+                        }
+                    });
+                    namesApi.receivePacketContext(context);
+                    expect(context.responses[0].response).toEqual("ok");
+                    expect(context.responses[0].entity).toContain(r.resource + "/testValue");
+                    expect(context.responses[0].contentType).toEqual(r.listContentType);
+                });
+
+                it("responds with badContent when missing the contentType", function () {
+                    var context = new TestPacketContext({
+                        'leaderState': "leader",
+                        'packet': {
+                            'resource': r.resource + "/testValue",
+                            'action': "set",
+                            'msgId': "1234",
+                            'src': "srcParticipant",
+                            'entity': {'foo': 1}
+                        }
+                    });
+                    namesApi.receivePacketContext(context);
+                    expect(context.responses[0].response).toEqual("badContent");
+
+                });
+
+                it("responds with badContent with invalid contentType", function () {
+                    var context = new TestPacketContext({
+                        'leaderState': "leader",
+                        'packet': {
+                            'resource': r.resource + "/testValue",
+                            'action': "set",
+                            'contentType': r.contentType + "+xml",
+                            'msgId': "1234",
+                            'src': "srcParticipant",
+                            'entity': {'foo': 1}
+                        }
+                    });
+                    namesApi.receivePacketContext(context);
+                    expect(context.responses[0].response).toEqual("badContent");
+                });
+
+            });
         });
-        pit("updates the collection when setting a value in the tree",function() {
-            var resourceName=r.resource + "/testValue";
-            namesApi.data[resourceName]=new ozpIwc.api.base.Node({
-                    'resource': resourceName,
-                    'contentType': r.contentType,
-                    'entity' : { 'foo' : 1 }
-            });
-            var context=new TestPacketContext({
-                'leaderState': "leader",
-                'packet': {
-                    'resource': r.resource,
-                    'action': "get",
-                    'msgId' : "1234",
-                    'src' : "srcParticipant"
-                }
-            });
-            return namesApi.receivePacketContext(context).then(function() {
-                expect(context.responses[0].response).toEqual("ok");
-                expect(context.responses[0].entity).toContain(r.resource + "/testValue");
-                expect(context.responses[0].contentType).toEqual(r.listContentType);
-            });
-
-        });
-        pit("responds with badContent when missing the contentType",function() {
-            var context=new TestPacketContext({
-                'leaderState': "leader",
-                'packet': {
-                    'resource': r.resource + "/testValue",
-                    'action': "set",
-                    'msgId' : "1234",
-                    'src' : "srcParticipant",
-                    'entity' : { 'foo' : 1 }
-                }
-            });
-            return namesApi.receivePacketContext(context).then(function() {
-               expect(context.responses[0].response).toEqual("badContent");
-            });
-
-        });
-
-        pit("responds with badContent with invalid contentType",function() {
-            var context=new TestPacketContext({
-                'leaderState': "leader",
-                'packet': {
-                    'resource': r.resource + "/testValue",
-                    'action': "set",
-                    'contentType': r.contentType+"+xml",
-                    'msgId' : "1234",
-                    'src' : "srcParticipant",
-                    'entity' : { 'foo' : 1 }
-                }
-            });
-            return namesApi.receivePacketContext(context).then(function() {
-               expect(context.responses[0].response).toEqual("badContent");
-            });
-        });
-
-    });});
-
-
 });

--- a/test/tests/unit/specs/services/system/systemApiSpec.js
+++ b/test/tests/unit/specs/services/system/systemApiSpec.js
@@ -1,4 +1,4 @@
-describe("System API", function() {
+describe("System API", function () {
 
     var systemApi;
     var applicationNode;
@@ -7,17 +7,17 @@ describe("System API", function() {
     var oldEndpoints;
     var applicationPacket = {
         'resource': "/application/abcApp",
-        'contentType' : "application/vnd.ozp-application-v1+json",
-        'version' : 1,
-        'entity' : {
-            "name" : "Blue Bouncing Ball",
-            "description" : "A blue bouncing ball",
-            "type" : "application",
-            "state" : "active",
+        'contentType': "application/vnd.ozp-application-v1+json",
+        'version': 1,
+        'entity': {
+            "name": "Blue Bouncing Ball",
+            "description": "A blue bouncing ball",
+            "type": "application",
+            "state": "active",
             "uiHints": {
-                "width" : 400,
-                "height" : 400,
-                "singleton" : false
+                "width": 400,
+                "height": 400,
+                "singleton": false
             },
             "tags": [
                 "demo"
@@ -30,32 +30,32 @@ describe("System API", function() {
                     "label": "Blue Ball"
                 }
             ],
-            "icons" : {
+            "icons": {
                 "small": "http://" + window.location.hostname + ":15000/largeIcon.png",
                 "large": "http://" + window.location.hostname + ":15000/smallIcon.png"
             },
-            "screenShots" : [
+            "screenShots": [
                 {
-                    "href" : "http://" + window.location.hostname + ":15000/screenShot.png",
-                    "title" : "A screenshot"
+                    "href": "http://" + window.location.hostname + ":15000/screenShot.png",
+                    "title": "A screenshot"
                 }
             ],
-            "launchUrls" : {
+            "launchUrls": {
                 "default": "http://" + window.location.hostname + ":15000/?color=blue",
-                "test" : "http://test.localhost:15000/?color=blue"
+                "test": "http://test.localhost:15000/?color=blue"
             },
             "_links": {
-                "self" : { "href": "/api/application/v1/12345"},
-                "describes" : { "href": "http://" + window.location.hostname + ":15000/?color=blue"}
+                "self": {"href": "/api/application/v1/12345"},
+                "describes": {"href": "http://" + window.location.hostname + ":15000/?color=blue"}
             }
         }
     };
-    beforeEach(function() {
-        oldEndpoints=ozpIwc.api.endpoint;
-        ozpIwc.api.endpoint=function() {
+    beforeEach(function () {
+        oldEndpoints = ozpIwc.api.endpoint;
+        ozpIwc.api.endpoint = function () {
             return {
-                get: function() { return Promise.resolve(); }
-            };            
+                get: function () { return Promise.resolve(); }
+            };
         };
         var fakeRouter = new FakeRouter();
         systemApi = new ozpIwc.api.system.Api({
@@ -73,16 +73,16 @@ describe("System API", function() {
         systemApi.createNode(applicationPacket);
     });
 
-    afterEach(function() {
+    afterEach(function () {
         systemApi = null;
-        ozpIwc.api.endpoint=oldEndpoints;
-        systemApi=null;
-        applicationNode=null;
-        userNode=null;
-        systemNode=null;
-     });
+        ozpIwc.api.endpoint = oldEndpoints;
+        systemApi = null;
+        applicationNode = null;
+        userNode = null;
+        systemNode = null;
+    });
 
-    pit("does not allow set on /application/{id}", function() {
+    it("does not allow set on /application/{id}", function () {
         var context = new TestPacketContext({
             'leaderState': "leader",
             'packet': {
@@ -97,12 +97,11 @@ describe("System API", function() {
                 }
             }
         });
-        return systemApi.receivePacketContext(context).then(function() {
-            expect(context.responses[0].response).toEqual("badAction");
-        });
+        systemApi.receivePacketContext(context);
+        expect(context.responses[0].response).toEqual("badAction");
     });
 
-    pit (" prevents user from deleting an application", function(){
+    it(" prevents user from deleting an application", function () {
         var context = new TestPacketContext({
             'leaderState': "leader",
             'packet': {
@@ -117,13 +116,12 @@ describe("System API", function() {
                 }
             }
         });
-        return systemApi.receivePacketContext(context).then(function() {
-            expect(context.responses[0].response).toEqual("badAction");
-        });
-		});
+        systemApi.receivePacketContext(context);
+        expect(context.responses[0].response).toEqual("badAction");
+    });
 
-    pit ("gets an application",function(){
-         var context = new TestPacketContext({
+    it("gets an application", function () {
+        var context = new TestPacketContext({
             'leaderState': "leader",
             'packet': {
                 'resource': "/application/abcApp",
@@ -137,47 +135,45 @@ describe("System API", function() {
                 }
             }
         });
-        return systemApi.receivePacketContext(context).then(function() {
-					var reply=context.responses[0];
-	        expect(reply.response).toEqual("ok");
-	        expect(reply.entity).toEqual(applicationPacket.entity);
-        });
+        systemApi.receivePacketContext(context);
+        var reply = context.responses[0];
+        expect(reply.response).toEqual("ok");
+        expect(reply.entity).toEqual(applicationPacket.entity);
     });
 
-    pit('handles launch actions', function(){
-        var launchData={
-                    'foo': 1
-                };
-        var packetContext=new TestPacketContext({
+    it('handles launch actions', function () {
+        var launchData = {
+            'foo': 1
+        };
+        var packetContext = new TestPacketContext({
             'packet': {
                 'resource': "/application/abcApp",
-                'entity' : launchData,
-								 action: 'launch'
+                'entity': launchData,
+                action: 'launch'
             }
         });
-        return systemApi.receivePacketContext(packetContext).then(function() {
-					var reply=packetContext.responses[0];
-					expect(reply.response).toEqual("ok");
-					expect(systemApi.participant).toHaveSent({
-						action: "invoke",
-						dst: "intents.api",
-						"entity": jasmine.objectContaining({
-							"url": "http://localhost:15000/?color=blue",
-							"applicationId": "/application/abcApp",
-							"launchData": {
-								"foo": 1
-							}
-						})
-					});
-				});
+        systemApi.receivePacketContext(packetContext);
+        var reply = packetContext.responses[0];
+        expect(reply.response).toEqual("ok");
+        expect(systemApi.participant).toHaveSent({
+            action: "invoke",
+            dst: "intents.api",
+            "entity": jasmine.objectContaining({
+                "url": "http://localhost:15000/?color=blue",
+                "applicationId": "/application/abcApp",
+                "launchData": {
+                    "foo": 1
+                }
+            })
+        });
     });
 
-    pit('handles invoke actions by launching applications', function(){
-        var packetContext=new TestPacketContext({
+    it('handles invoke actions by launching applications', function () {
+        var packetContext = new TestPacketContext({
             'packet': {
                 'resource': "/launchNewWindow",
                 action: 'invoke',
-                'entity' : {
+                'entity': {
                     'foo': 1,
                     'inFlightIntent': {
                         'resource': '/intents/invocation/123',
@@ -189,20 +185,19 @@ describe("System API", function() {
                             }
                         }
                     }
-                      
+
                 }
             }
         });
-        spyOn( ozpIwc.util,"openWindow");
-        return systemApi.receivePacketContext(packetContext).then(function() {
-                expect(packetContext).toHaveSent({
-                    "response":"ok"
-                });
+        spyOn(ozpIwc.util, "openWindow");
+        systemApi.receivePacketContext(packetContext);
+        expect(packetContext).toHaveSent({
+            "response": "ok"
+        });
 
-                expect(ozpIwc.util.openWindow.calls.mostRecent().args[0]).toEqual("http://" + window.location.hostname + ":15000/?color=blue");
-                var params=ozpIwc.util.openWindow.calls.mostRecent().args[1];
-                expect(params['ozpIwc.peer']).toEqual(ozpIwc.config._busRoot);
-                expect(params['ozpIwc.inFlightIntent']).toEqual(packetContext.packet.entity.inFlightIntent.resource);
-            });
+        expect(ozpIwc.util.openWindow.calls.mostRecent().args[0]).toEqual("http://" + window.location.hostname + ":15000/?color=blue");
+        var params = ozpIwc.util.openWindow.calls.mostRecent().args[1];
+        expect(params['ozpIwc.peer']).toEqual(ozpIwc.config._busRoot);
+        expect(params['ozpIwc.inFlightIntent']).toEqual(packetContext.packet.entity.inFlightIntent.resource);
     });
 });


### PR DESCRIPTION
#333 #330 

added `ozpIwc.util.setTimeout`, `ozpIwc.util.clearTimeout`, `ozpIwc.util.setInterval`, `ozpIwc.util.clearInterval`. Experimental feature of the IWC, To enable add parameter `enhancedTimers: true` to Client instantiation. This allows timers to not clamp to  a minimum at 1 second when page is not visible. Gitbook updates to follow.

feat(sharedWebWorker): Initial build. Functioning but needs optimization.
feat(sharedWebWorker): Fixed memory leak of watch actions.
feat(sharedWorker): moved port message handler to participant.
feat(sharedWorker): Initial attempt at adding a sharedWorker timer for better hidden-tab performance.
feat(sharedWorker): Added util functions for using sharedworker timers.
feat(sharedWorker): updated bouncing balls to use experimental timers. Updated tests for promise restructure.
feat(sharedWorker): Updated intent tests.
feat(sharedWebWorker): Updated integration tests for better reliability.
feat(sharedWebWorker): Fixed client to only accept packets for itself (if multi-client in window). Added json parsing for packets from shared worker if needed.
feat(jshint): Added jasmine globals beforeAll afterAll.