### PR TITLE
Passing data to launching Application.

### DIFF
--- a/app/js/client/client.js
+++ b/app/js/client/client.js
@@ -318,11 +318,27 @@ ozpIwc.Client = (function (util) {
     /**
      * Client to Bus sending implementation. Not to be used directly.
      * @private
-     * @method sendImpl.
+     * @method sendImpl
      * @param {ozpIwc.TransportPacket} packet
      */
     Client.prototype.sendImpl = function (packet) {
         util.safePostMessage(this.peer, packet, '*');
+    };
+
+    /**
+     * Gathers the launch data passed to the opened application. Launch data can be passed as a query parameter, inside
+     * window.name, or inside window.hash as long as it's key is "launchData".
+     *
+     * Promise resolve with the launchData object.
+     *
+     * @method getLaunchData
+     * @returns {Promise}
+     */
+    Client.prototype.getLaunchData = function(){
+        var self = this;
+        return this.connect().then(function() {
+            return self.launchParams.launchData;
+        });
     };
 
     return Client;

--- a/docs/iwc_guide/client/apis/system/launch.md
+++ b/docs/iwc_guide/client/apis/system/launch.md
@@ -28,10 +28,27 @@ var data = {
 systemApi.launch("/application/ea0c6018-4f12-410d-93b7-fe925b3a6ca2",{entity: data});
 ```
 
-The launched application can gather the launch data after it's client has connected as so:
+The launched application can gather the launch data using the `getLaunchData` method. It uses promises to resolve after
+the client has connected:
 ```
-var launchParams = {};
-client.connect().then(function(){
-    launchParams = client.launchParams;
+var launchData = {};
+client.getLaunchData().then(function(data){
+    launchData= data;
 });
+```
+###Passing launch parameters Without using the System API
+Alternatively, launch data can be passed to the opening application in the following places so long as the `key` is 
+`ozpIwc.launchData`:
+
+* window.name
+* Url query parameter: `(?launchData=<stringified & URI-encoded object>)`
+    * LaunchData persists through browser refresh (good for when sharing a URL of a application occurs).
+* Url hash: `(#launchData=<stringified & URIencoded  object>)`
+    * LaunchData does not persist through browser refresh (good for when launching an application to handle the launch data for a unique one-time need).
+    
+To stringify and URI-encode a value in javascript:
+```
+var obj = {'a': 1};
+var stringified = JSON.stringify(obj);
+var uriEncoded = encodeURIcomponent(stringified);
 ```

--- a/test/tests/client-integration/specs/clientSpec.js
+++ b/test/tests/client-integration/specs/clientSpec.js
@@ -60,6 +60,19 @@ describe("IWC Client", function () {
                 return client2.disconnect();
             });
         });
+
+        pit("gets launchData from hash", function(){
+            client.readLaunchParams("#ozpIwc.launchData=%7B%22channel%22%3A1%7D");
+            return client.getLaunchData().then(function(launchData){
+                expect(launchData).toEqual({'channel':1});
+            });
+        });
+        pit("gets launchData from query", function(){
+            client.readLaunchParams("?ozpIwc.launchData=%7B%22channel%22%3A1%7D");
+            return client.getLaunchData().then(function(launchData){
+                expect(launchData).toEqual({'channel':1});
+            });
+        });
     });
 
     describe("launch parameters", function () {


### PR DESCRIPTION
feat(launchData): Added easier retrieval of launch data with Client.getLaunchData(). Docs included.

See [launching docs](http://ozone-development.github.io/ozp-iwc/client/apis/system/launch.html) for information on passing data with System.api launching, as well as from the URL. (Docs update on IWC version, will be visible with 1.1.5).