### PR TITLE
fix(client): prevent beforeunload from opening prompt in IE 11.

### DIFF
--- a/app/js/client/client.js
+++ b/app/js/client/client.js
@@ -28,7 +28,10 @@ ozpIwc.Client = (function (util) {
         }
         this.type = "default";
 
-        util.addEventListener('beforeunload', this.disconnect);
+        var self = this;
+        util.addEventListener('beforeunload', function(){
+            self.disconnect();
+        });
         genPeerUrlCheck(this, config.peerUrl);
         util.ApiPromiseMixin(this, config.autoConnect);
 


### PR DESCRIPTION
refs #347 