### PR TITLE
Watch & Collect enhancements

### DIFF
--- a/src/js/bus/api/base/node.js
+++ b/src/js/bus/api/base/node.js
@@ -335,7 +335,7 @@ ozpIwc.api.base.Node = (function (api, ozpConfig, util) {
         }
         this.lifespan = api.Lifespan.getLifespan(this, packet) || this.lifespan;
         this.contentType = packet.contentType || this.contentType;
-        this.entity = packet.entity;
+        this.entity = packet.entity || this.entity;
         this.pattern = packet.pattern || this.pattern;
         this.deleted = false;
         if (packet.eTag) {

--- a/src/js/bus/api/services/intents/routes.js
+++ b/src/js/bus/api/services/intents/routes.js
@@ -16,7 +16,10 @@ ozpIwc.api.intents.Api = (function (api, IntentsApi, log) {
     IntentsApi.useDefaultRoute(["bulkGet", "list"]);
     IntentsApi.useDefaultRoute(["watch", "unwatch", "delete"], "/inFlightIntent/{id}");
     IntentsApi.useDefaultRoute(["get", "delete", "watch", "unwatch"], "/{major}/{minor}/{action}/{handlerId}");
-    IntentsApi.useDefaultRoute(["delete", "watch", "unwatch", "get"], "/{major}/{minor}/{action}");
+    IntentsApi.useDefaultRoute(["get", "delete", "watch", "unwatch"], "/{major}/{minor}/{action}");
+    IntentsApi.useDefaultRoute(["watch", "unwatch", "get"], "/");
+    IntentsApi.useDefaultRoute(["watch", "unwatch", "get"], "/{major}");
+    IntentsApi.useDefaultRoute(["watch", "unwatch", "get"], "/{major}/{minor}");
 
 //---------------------------------------------------------
 // Filters


### PR DESCRIPTION
feat(api): Added collect flag to watch requests for collecting.
feat(api): added collect option on watch requests.

***

Previously a pattern had to be set on a resource then a watch requested to collect resources under said resource.

Now using the `collect:true` property on a *watch* request will start collection on all resources prefix-matching the resources `pattern` property (can be supplied with the watch).