### PR TITLE
Intents error handling.

### DIFF
--- a/src/js/bus/api/services/intents/api.js
+++ b/src/js/bus/api/services/intents/api.js
@@ -163,6 +163,9 @@ ozpIwc.api.intents.Api = (function (api, log, ozpConfig, util) {
             case "complete":
                 this.handleComplete(inflightNode);
                 break;
+            case "error":
+                this.handleError(inflightNode);
+                break;
             default:
                 updateInvoker(this, inflightNode);
                 break;
@@ -322,6 +325,28 @@ ozpIwc.api.intents.Api = (function (api, log, ozpConfig, util) {
                 replyTo: node.entity.invokePacket.msgId,
                 contentType: node.entity.reply.contentType,
                 response: "complete",
+                resource: node.entity.handler.resource,
+                entity: node.entity.reply.entity
+            });
+            updateInvoker(this, node);
+        }
+        node.markAsDeleted();
+    };
+    /**
+     * A handler for the "error" state of an in-flight intent node.
+     * Sends notification to the invoker that the intent was handled & deletes the in-flight intent node as it is no
+     * longer needed.
+     *
+     * @method handleError
+     * @param {ozpIwc.api.base.Node} node
+     */
+    Api.prototype.handleError = function (node) {
+        if (node.entity.invokePacket && node.entity.invokePacket.src) {
+            this.send({
+                dst: node.entity.invokePacket.src,
+                replyTo: node.entity.invokePacket.msgId,
+                contentType: node.entity.reply.contentType,
+                response: "noResult",
                 resource: node.entity.handler.resource,
                 entity: node.entity.reply.entity
             });

--- a/src/js/bus/api/services/intents/fsm.js
+++ b/src/js/bus/api/services/intents/fsm.js
@@ -92,8 +92,12 @@ ozpIwc.api.intents.FSM = (function (api, util) {
      * @return {ozpIwc.api.base.Node}
      */
     FSM.states.error = function (entity) {
+        var reply = entity.reply || {};
+        reply.entity = reply.entity || "Unknown Error.";
+        reply.contentType = reply.contentType || "text/plain";
+
         this.entity = this.entity || {};
-        this.entity.reply = entity.error;
+        this.entity.reply = reply;
         this.entity.state = "error";
         this.version++;
         return FSM.stateEvent(this);

--- a/src/js/common/apiPromiseMixin.js
+++ b/src/js/common/apiPromiseMixin.js
@@ -491,8 +491,8 @@ ozpIwc.util.ApiPromiseMixin = (function (apiMap, log, util) {
                         resource: res.resource,
                         entity: {
                             reply: {
-                                'entity': e || {},
-                                'contentType': res.entity.intent.type
+                                'entity': e.toString() || {},
+                                'contentType': "text/plain"
                             },
                             state: "error"
                         }

--- a/test/tests/client-integration/specs/apis/intentsApiSpec.js
+++ b/test/tests/client-integration/specs/apis/intentsApiSpec.js
@@ -107,4 +107,17 @@ describe("Intents Api", function () {
             });
         });
     });
+
+    pit("returns the error message to the invoker if failed to be handled.", function(){
+        var err;
+        return intentsApi.register('/foo/bar/buz', function(resp){
+            err = new Error("This.is an error.");
+            throw err;
+        }).then(function(){
+            return intentsApi.invoke("/foo/bar/buz");
+        }).catch(function(response){
+            expect(response.entity).toEqual(err.toString());
+            expect(response.response).toEqual("noResult");
+        });
+    });
 });

--- a/test/tests/unit/specs/api/intents/InflightIntentNodeSpec.js
+++ b/test/tests/unit/specs/api/intents/InflightIntentNodeSpec.js
@@ -114,9 +114,15 @@ describe("Intents in Flight Value", function () {
     });
     it("transitions from choosing to error on receiving a error packet", function () {
         var node = makeNode();
-        node = ozpIwc.api.intents.FSM.transition(node, {'entity': {'state': "error", 'error': "Unknown Error"}});
+        node = ozpIwc.api.intents.FSM.transition(node, {
+            'entity': {
+                'state': "error",
+                'reply': {'entity': "Unknown Error", 'contentType': "application/vnd.custom"}
+            }
+        });
         expect(node.entity.state).toEqual("error");
-        expect(node.entity.reply).toEqual("Unknown Error");
+        expect(node.entity.reply.entity).toEqual("Unknown Error");
+        expect(node.entity.reply.contentType).toEqual("application/vnd.custom");
     });
     it("throws badState if the set lacks resource or reason", function () {
         var node = makeNode();
@@ -170,9 +176,15 @@ describe("Intents in Flight Value", function () {
         });
 
         it("transitions from delivering to error on receiving a error packet", function () {
-            node = ozpIwc.api.intents.FSM.transition(node, {'entity': {'state': "error", 'error': "Unknown Error"}});
+            node = ozpIwc.api.intents.FSM.transition(node, {
+                'entity': {
+                    'state': "error",
+                    'reply': {'entity': "Unknown Error", 'contentType': "application/vnd.custom"}
+                }
+            });
+
             expect(node.entity.state).toEqual("error");
-            expect(node.entity.reply).toEqual("Unknown Error");
+            expect(node.entity.reply.entity).toEqual("Unknown Error");
         });
 
         it("throws badState if the set lacks an address", function () {
@@ -214,11 +226,13 @@ describe("Intents in Flight Value", function () {
             node = ozpIwc.api.intents.FSM.transition(node, {
                 'entity': {
                     'state': "error",
-                    'error': "Unknown Error"
+                    reply: {
+                        'entity': "Unknown Error"
+                    }
                 }
             });
             expect(node.entity.state).toEqual("error");
-            expect(node.entity.reply).toEqual("Unknown Error");
+            expect(node.entity.reply.entity).toEqual("Unknown Error");
         });
 
         it("to complete on receiving a 'complete' packet", function () {


### PR DESCRIPTION
#372 
fix(intents): Added error handler. for Intents responding with a thrown error.

fix(intents): Added noResult response for failed intents.
feat(intents): Intent handlers now can throw error messages for the invoker to receive.

fix(intents): error message contentType set to 'text/plain' as the Error is a readable string.

feat(tests): Updated intent error handling tests.

feat(tests): Added integration testing for intent error handling.